### PR TITLE
feat: add cross-platform support for editor adapters

### DIFF
--- a/editors/base.js
+++ b/editors/base.js
@@ -1,4 +1,27 @@
+const path = require('path');
+const os = require('os');
 const chalk = require('chalk');
+
+const HOME = os.homedir();
+
+// --- Platform utilities ---
+
+/**
+ * Get platform-specific app data directory path for VS Code-like editors.
+ * - macOS: ~/Library/Application Support/{appName}/User/...
+ * - Windows: ~/AppData/Roaming/{appName}/User/...
+ * - Linux: ~/.config/{appName}/User/...
+ */
+function getAppDataPath(appName) {
+  switch (process.platform) {
+    case 'darwin':
+      return path.join(HOME, 'Library', 'Application Support', appName);
+    case 'win32':
+      return path.join(HOME, 'AppData', 'Roaming', appName);
+    default: // linux, etc.
+      return path.join(HOME, '.config', appName);
+  }
+}
 
 // --- Formatting utilities shared across all editor adapters ---
 
@@ -117,6 +140,7 @@ function shortenPath(p, maxLen = 40) {
  */
 
 module.exports = {
+  getAppDataPath,
   formatArgs,
   formatToolCall,
   formatToolResult,

--- a/editors/cursor.js
+++ b/editors/cursor.js
@@ -2,11 +2,13 @@ const Database = require('better-sqlite3');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
+const { getAppDataPath } = require('./base');
 
 const HOME = os.homedir();
 const CURSOR_CHATS_DIR = path.join(HOME, '.cursor', 'chats');
-const WORKSPACE_STORAGE_DIR = path.join(HOME, 'Library', 'Application Support', 'Cursor', 'User', 'workspaceStorage');
-const GLOBAL_STORAGE_DB = path.join(HOME, 'Library', 'Application Support', 'Cursor', 'User', 'globalStorage', 'state.vscdb');
+const CURSOR_USER_DIR = path.join(getAppDataPath('Cursor'), 'User');
+const WORKSPACE_STORAGE_DIR = path.join(CURSOR_USER_DIR, 'workspaceStorage');
+const GLOBAL_STORAGE_DB = path.join(CURSOR_USER_DIR, 'globalStorage', 'state.vscdb');
 
 // ============================================================
 // Source 1: ~/.cursor/chats/<hash>/<chatId>/store.db (agent KV)

--- a/editors/vscode.js
+++ b/editors/vscode.js
@@ -1,18 +1,17 @@
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
-
-const HOME = os.homedir();
+const { getAppDataPath } = require('./base');
 
 // VS Code variants: stable and insiders
 const VARIANTS = [
   {
     id: 'vscode',
-    appSupport: path.join(HOME, 'Library', 'Application Support', 'Code'),
+    appSupport: getAppDataPath('Code'),
   },
   {
     id: 'vscode-insiders',
-    appSupport: path.join(HOME, 'Library', 'Application Support', 'Code - Insiders'),
+    appSupport: getAppDataPath('Code - Insiders'),
   },
 ];
 

--- a/editors/zed.js
+++ b/editors/zed.js
@@ -2,9 +2,9 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 const { execSync } = require('child_process');
+const { getAppDataPath } = require('./base');
 
-const HOME = os.homedir();
-const THREADS_DB = path.join(HOME, 'Library', 'Application Support', 'Zed', 'threads', 'threads.db');
+const THREADS_DB = path.join(getAppDataPath('Zed'), 'threads', 'threads.db');
 
 // ============================================================
 // Decompress zstd blob via CLI


### PR DESCRIPTION
Add getAppDataPath() helper to base.js that returns platform-specific app data directories (macOS/Windows/Linux). Update cursor, vscode, and zed adapters to use this helper instead of hardcoded macOS paths.