### PR TITLE
fix: add pricing.js and pricing.json to package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   "files": [
     "index.js",
     "cache.js",
+    "pricing.js",
+    "pricing.json",
     "server.js",
     "share-image.js",
     "relay-server.js",


### PR DESCRIPTION
## Summary

- `cache.js` requires `./pricing`, but `pricing.js` and `pricing.json` are missing from the `files` array in `package.json`
- This causes `npx agentlytics` to crash with `MODULE_NOT_FOUND` since these files are not included in the published npm package

## Reproduce

```
npx agentlytics
```

```
Error: Cannot find module './pricing'
Require stack:
- .../agentlytics/cache.js
- .../agentlytics/index.js
```

## Fix

Added `pricing.js` and `pricing.json` to the `files` array in `package.json`.

Verified with `npm pack --dry-run` that both files are now included in the package.