### PR TITLE
fix(codex): prevent cached input double-counting in cost calculation

### DIFF
--- a/editors/codex.js
+++ b/editors/codex.js
@@ -376,9 +376,11 @@ function subtractRawUsage(current, previous) {
 }
 
 function convertToDelta(raw) {
+  const cacheRead = Math.min(raw.cached_input_tokens, raw.input_tokens);
+  const billableInput = Math.max(raw.input_tokens - cacheRead, 0);
   return {
-    inputTokens: raw.input_tokens,
-    cacheRead: Math.min(raw.cached_input_tokens, raw.input_tokens),
+    inputTokens: billableInput,
+    cacheRead,
     outputTokens: raw.output_tokens,
     totalTokens: raw.total_tokens > 0 ? raw.total_tokens : raw.input_tokens + raw.output_tokens,
   };


### PR DESCRIPTION
This PR fixes Codex cost accounting by subtracting cached input tokens from billable input and charging them only as cache reads. This prevents double-counting and makes Codex cost estimates more accurate.