### PR TITLE
fix: Windows compatibility for WMIC, npx, and shell commands

### DIFF
--- a/editors/antigravity.js
+++ b/editors/antigravity.js
@@ -1,4 +1,4 @@
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 const os = require('os');
 
 // Static fallback for legacy placeholders no longer returned by the LS
@@ -62,16 +62,19 @@ const IS_WINDOWS = process.platform === 'win32';
 function getProcessList() {
   try {
     if (IS_WINDOWS) {
-      const output = execSync('wmic process get CommandLine,ProcessId /format:csv', {
+      // Use PowerShell Get-Process (WMIC is deprecated in Windows 10/11)
+      const output = execFileSync('powershell', ['-Command', 'Get-Process | Select-Object Id, Path, CommandLine | ConvertTo-Csv -NoTypeInformation'], {
         encoding: 'utf-8',
         maxBuffer: 10 * 1024 * 1024,
       });
+      // Parse CSV: skip header
       const lines = output.split('\n').slice(1);
       return lines.map(line => {
         const parts = line.split(',');
-        if (parts.length < 2) return null;
-        const commandLine = parts.slice(0, -1).join(',').trim().replace(/^"|"$/g, '');
-        const pid = parts[parts.length - 1].trim();
+        if (parts.length < 3) return null;
+        const pid = parts[0].trim().replace(/^"|"$/g, '');
+        const commandLine = parts[2].trim().replace(/^"|"$/g, '');
+        if (!pid || !commandLine) return null;
         return { commandLine, pid };
       }).filter(Boolean);
     } else {
@@ -90,7 +93,8 @@ function getProcessList() {
 function getListeningPorts(pid) {
   try {
     if (IS_WINDOWS) {
-      const output = execSync(`netstat -ano | findstr ${pid}`, {
+      // Use PowerShell to get netstat output and filter by PID
+      const output = execFileSync('powershell', ['-Command', `netstat -ano | Select-String "${pid}$"`], {
         encoding: 'utf-8',
         maxBuffer: 10 * 1024 * 1024,
       });

--- a/editors/goose.js
+++ b/editors/goose.js
@@ -1,24 +1,36 @@
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
-const { execSync } = require('child_process');
 
 const GOOSE_DIR = path.join(os.homedir(), '.local', 'share', 'goose', 'sessions');
 const DB_PATH = path.join(GOOSE_DIR, 'sessions.db');
 const CONFIG_PATH = path.join(os.homedir(), '.config', 'goose', 'config.yaml');
 
 // ============================================================
-// Query SQLite via CLI
+// Query SQLite via better-sqlite3 (cross-platform)
 // ============================================================
+
+let Database;
+function getDatabase() {
+  if (!Database) {
+    try {
+      Database = require('better-sqlite3');
+    } catch {
+      // better-sqlite3 not available
+    }
+  }
+  return Database;
+}
 
 function queryDb(sql) {
   if (!fs.existsSync(DB_PATH)) return [];
+  const Db = getDatabase();
+  if (!Db) return []; // Fallback if better-sqlite3 not available
   try {
-    const raw = execSync(
-      `sqlite3 -json ${JSON.stringify(DB_PATH)} ${JSON.stringify(sql)}`,
-      { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024, stdio: ['pipe', 'pipe', 'pipe'] }
-    );
-    return JSON.parse(raw);
+    const db = new Db(DB_PATH, { readonly: true });
+    const rows = db.prepare(sql).all();
+    db.close();
+    return rows;
   } catch { return []; }
 }
 

--- a/editors/windsurf.js
+++ b/editors/windsurf.js
@@ -1,4 +1,4 @@
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 const path = require('path');
 const os = require('os');
 const fs = require('fs');
@@ -18,18 +18,19 @@ const IS_WINDOWS = process.platform === 'win32';
 function getProcessList() {
   try {
     if (IS_WINDOWS) {
-      // wmic provides CSV-formatted process data
-      const output = execSync('wmic process get CommandLine,ProcessId /format:csv', {
+      // Use PowerShell Get-Process (WMIC is deprecated in Windows 10/11)
+      const output = execFileSync('powershell', ['-Command', 'Get-Process | Select-Object Id, Path, CommandLine | ConvertTo-Csv -NoTypeInformation'], {
         encoding: 'utf-8',
         maxBuffer: 10 * 1024 * 1024,
       });
-      // Parse CSV: skip header, split by comma
+      // Parse CSV: skip header
       const lines = output.split('\n').slice(1);
       return lines.map(line => {
         const parts = line.split(',');
-        if (parts.length < 2) return null;
-        const commandLine = parts.slice(0, -1).join(',').trim().replace(/^"|"$/g, '');
-        const pid = parts[parts.length - 1].trim();
+        if (parts.length < 3) return null;
+        const pid = parts[0].trim().replace(/^"|"$/g, '');
+        const commandLine = parts[2].trim().replace(/^"|"$/g, '');
+        if (!pid || !commandLine) return null;
         return { commandLine, pid };
       }).filter(Boolean);
     } else {
@@ -49,8 +50,8 @@ function getProcessList() {
 function getListeningPorts(pid) {
   try {
     if (IS_WINDOWS) {
-      // netstat -ano shows PID in the last column
-      const output = execSync(`netstat -ano | findstr ${pid}`, {
+      // Use PowerShell to get netstat output and filter by PID
+      const output = execFileSync('powershell', ['-Command', `netstat -ano | Select-String "${pid}$"`], {
         encoding: 'utf-8',
         maxBuffer: 10 * 1024 * 1024,
       });

--- a/editors/zed.js
+++ b/editors/zed.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
-const { execSync } = require('child_process');
 
 const Database = require('better-sqlite3');
 
@@ -24,7 +23,7 @@ function getZedDataPath() {
 const THREADS_DB = path.join(getZedDataPath(), 'threads', 'threads.db');
 
 // ============================================================
-// Decompress zstd blob via CLI
+// Decompress zstd blob via CLI (with cross-platform support)
 // ============================================================
 
 function decompressZstd(buf) {
@@ -32,7 +31,28 @@ function decompressZstd(buf) {
   const tmpOut = tmpIn.replace('.zst', '.json');
   try {
     fs.writeFileSync(tmpIn, buf);
-    execSync(`zstd -d -f -q ${JSON.stringify(tmpIn)} -o ${JSON.stringify(tmpOut)}`, { stdio: ['pipe', 'pipe', 'pipe'] });
+
+    // Try zstd CLI first
+    try {
+      const { execFileSync } = require('child_process');
+      const zstdCmd = process.platform === 'win32' ? 'zstd.exe' : 'zstd';
+      execFileSync(zstdCmd, ['-d', '-f', '-q', tmpIn, '-o', tmpOut], { stdio: ['pipe', 'pipe', 'pipe'] });
+    } catch {
+      // Fallback: try using Node.js zstd library if available
+      try {
+        const zlib = require('zlib');
+        // Check if Node version supports zstd natively (v22+)
+        if (zlib.createZstdDecompress) {
+          const decompressed = zlib.zstdDecompressSync(buf);
+          fs.writeFileSync(tmpOut, decompressed);
+        } else {
+          throw new Error('zstd not available');
+        }
+      } catch {
+        throw new Error('zstd decompression not available on this system');
+      }
+    }
+
     const data = fs.readFileSync(tmpOut, 'utf-8');
     return data;
   } finally {

--- a/server.js
+++ b/server.js
@@ -338,8 +338,15 @@ app.get('/api/check-ai', async (req, res) => {
   if (!folder) return res.status(400).json({ error: 'folder query param required' });
   try {
     const { execFile } = require('child_process');
+    const isWindows = process.platform === 'win32';
+    // On Windows, use npx.cmd with shell; on Unix, use npx directly
+    const cmd = isWindows ? 'npx.cmd' : 'npx';
     const result = await new Promise((resolve, reject) => {
-      execFile('npx', ['-y', 'check-ai', '--json', folder], { timeout: 60000, maxBuffer: 1024 * 1024 }, (err, stdout) => {
+      execFile(cmd, ['-y', 'check-ai', '--json', folder], {
+        timeout: 60000,
+        maxBuffer: 1024 * 1024,
+        shell: isWindows
+      }, (err, stdout) => {
         try {
           const json = JSON.parse(stdout);
           resolve(json);

--- a/ui/src/components/AiAuditCard.jsx
+++ b/ui/src/components/AiAuditCard.jsx
@@ -68,13 +68,14 @@ function Tip({ missing }) {
 }
 
 export default function AiAuditCard({ folder }) {
+  console.log('AiAuditCard rendering, folder:', folder)
   const [audit, setAudit] = useState(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
   const [expanded, setExpanded] = useState(new Set())
-  const ran = useRef(false)
 
   const runAudit = async () => {
+    if (!folder) return
     setLoading(true)
     setError(null)
     try {
@@ -88,10 +89,8 @@ export default function AiAuditCard({ folder }) {
   }
 
   useEffect(() => {
-    if (folder && !ran.current) {
-      ran.current = true
-      runAudit()
-    }
+    console.log('AiAuditCard useEffect triggered, folder:', folder)
+    runAudit()
   }, [folder])
 
   if (loading) {

--- a/ui/src/pages/ProjectDetail.jsx
+++ b/ui/src/pages/ProjectDetail.jsx
@@ -235,6 +235,7 @@ export default function ProjectDetail() {
       </div>
 
       {/* AI Readiness Audit */}
+      {console.log('Rendering AiAuditCard, folder:', folder)}
       <AiAuditCard folder={folder} />
 
       {/* Sessions */}


### PR DESCRIPTION
- Replace deprecated WMIC with PowerShell Get-Process in windsurf.js
- Replace deprecated WMIC with PowerShell Get-Process in antigravity.js
- Fix npx spawn error on Windows using npx.cmd with shell option (server.js)
- Replace sqlite3 CLI with better-sqlite3 in goose.js for cross-platform support
- Add fallback for zstd decompression in zed.js (CLI + Node.js zlib)
- Fix AiAuditCard useEffect to properly trigger on folder change