### PR TITLE
fix: correct cache hit rate and token flow calculations

### DIFF
--- a/ui/src/pages/Dashboard.jsx
+++ b/ui/src/pages/Dashboard.jsx
@@ -163,7 +163,8 @@ export default function Dashboard({ overview }) {
   } : null
 
   const tk = stats?.tokens
-  const cacheHitRate = tk && tk.input > 0 ? ((tk.cacheRead / tk.input) * 100).toFixed(1) : 0
+  const totalInputWithCache = tk ? tk.input + tk.cacheRead : 0
+  const cacheHitRate = totalInputWithCache > 0 ? ((tk.cacheRead / totalInputWithCache) * 100).toFixed(1) : 0
   const outputInputRatio = tk && tk.input > 0 ? (tk.output / tk.input).toFixed(2) : 0
   const avgMsgsPerSession = tk && tk.sessions > 0 ? (depthData ? (Object.values(stats.depthBuckets).reduce((s, v, i) => {
     const labels = Object.keys(stats.depthBuckets)

--- a/ui/src/pages/Dashboard.jsx
+++ b/ui/src/pages/Dashboard.jsx
@@ -163,8 +163,8 @@ export default function Dashboard({ overview }) {
   } : null
 
   const tk = stats?.tokens
-  const totalInputWithCache = tk ? tk.input + tk.cacheRead : 0
-  const cacheHitRate = totalInputWithCache > 0 ? ((tk.cacheRead / totalInputWithCache) * 100).toFixed(1) : 0
+  const totalInputAll = tk ? tk.input + tk.cacheRead + (tk.cacheWrite || 0) : 0
+  const cacheHitRate = totalInputAll > 0 ? ((tk.cacheRead / totalInputAll) * 100).toFixed(1) : 0
   const outputInputRatio = tk && tk.input > 0 ? (tk.output / tk.input).toFixed(2) : 0
   const avgMsgsPerSession = tk && tk.sessions > 0 ? (depthData ? (Object.values(stats.depthBuckets).reduce((s, v, i) => {
     const labels = Object.keys(stats.depthBuckets)

--- a/ui/src/pages/Dashboard.jsx
+++ b/ui/src/pages/Dashboard.jsx
@@ -165,7 +165,7 @@ export default function Dashboard({ overview }) {
   const tk = stats?.tokens
   const totalInputAll = tk ? tk.input + tk.cacheRead + (tk.cacheWrite || 0) : 0
   const cacheHitRate = totalInputAll > 0 ? ((tk.cacheRead / totalInputAll) * 100).toFixed(1) : 0
-  const outputInputRatio = tk && tk.input > 0 ? (tk.output / tk.input).toFixed(2) : 0
+  const outputInputRatio = totalInputAll > 0 ? (tk.output / totalInputAll).toFixed(3) : 0
   const avgMsgsPerSession = tk && tk.sessions > 0 ? (depthData ? (Object.values(stats.depthBuckets).reduce((s, v, i) => {
     const labels = Object.keys(stats.depthBuckets)
     const midpoints = [1, 3.5, 8, 15.5, 35.5, 75.5, 150]

--- a/ui/src/pages/DeepAnalysis.jsx
+++ b/ui/src/pages/DeepAnalysis.jsx
@@ -230,7 +230,8 @@ export default function DeepAnalysis({ overview }) {
     const msgsPerSession = data.analyzedChats > 0 ? (data.totalMessages / data.analyzedChats).toFixed(1) : 0
     const toolsPerSession = data.analyzedChats > 0 ? (data.totalToolCalls / data.analyzedChats).toFixed(1) : 0
     const tokPerMsg = data.totalMessages > 0 ? Math.round(totalTok / data.totalMessages) : 0
-    const cacheHitRate = data.totalInputTokens > 0 ? ((data.totalCacheRead / data.totalInputTokens) * 100).toFixed(1) : 0
+    const totalInputWithCache = data.totalInputTokens + data.totalCacheRead
+    const cacheHitRate = totalInputWithCache > 0 ? ((data.totalCacheRead / totalInputWithCache) * 100).toFixed(1) : 0
     const outputRatio = data.totalInputTokens > 0 ? (data.totalOutputTokens / data.totalInputTokens).toFixed(2) : 0
     const aiVsHuman = data.totalUserChars > 0 ? (data.totalAssistantChars / data.totalUserChars).toFixed(1) : 0
     return { totalTok, msgsPerSession, toolsPerSession, tokPerMsg, cacheHitRate, outputRatio, aiVsHuman }
@@ -299,14 +300,14 @@ export default function DeepAnalysis({ overview }) {
                 <div>
                   <div className="flex items-center justify-between text-[11px] mb-1">
                     <span style={{ color: 'var(--c-text2)' }}>input tokens</span>
-                    <span className="font-bold" style={{ color: 'var(--c-white)' }}>{formatNumber(data.totalInputTokens)}</span>
+                    <span className="font-bold" style={{ color: 'var(--c-white)' }}>{formatNumber(data.totalInputTokens + data.totalCacheRead)}</span>
                   </div>
                   <ProportionBar segments={[
-                    { label: 'Fresh input', value: data.totalInputTokens - data.totalCacheRead, color: '#6366f1' },
+                    { label: 'Fresh input', value: data.totalInputTokens, color: '#6366f1' },
                     { label: 'Cache read', value: data.totalCacheRead, color: '#34d399' },
                   ]} />
                   <div className="flex items-center gap-3 mt-1 text-[10px]">
-                    <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-sm" style={{ background: '#6366f1' }} /> fresh {formatNumber(data.totalInputTokens - data.totalCacheRead)}</span>
+                    <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-sm" style={{ background: '#6366f1' }} /> fresh {formatNumber(data.totalInputTokens)}</span>
                     <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-sm" style={{ background: '#34d399' }} /> cached {formatNumber(data.totalCacheRead)}</span>
                   </div>
                 </div>

--- a/ui/src/pages/DeepAnalysis.jsx
+++ b/ui/src/pages/DeepAnalysis.jsx
@@ -230,8 +230,8 @@ export default function DeepAnalysis({ overview }) {
     const msgsPerSession = data.analyzedChats > 0 ? (data.totalMessages / data.analyzedChats).toFixed(1) : 0
     const toolsPerSession = data.analyzedChats > 0 ? (data.totalToolCalls / data.analyzedChats).toFixed(1) : 0
     const tokPerMsg = data.totalMessages > 0 ? Math.round(totalTok / data.totalMessages) : 0
-    const totalInputWithCache = data.totalInputTokens + data.totalCacheRead
-    const cacheHitRate = totalInputWithCache > 0 ? ((data.totalCacheRead / totalInputWithCache) * 100).toFixed(1) : 0
+    const totalInputAll = data.totalInputTokens + data.totalCacheRead + data.totalCacheWrite
+    const cacheHitRate = totalInputAll > 0 ? ((data.totalCacheRead / totalInputAll) * 100).toFixed(1) : 0
     const outputRatio = data.totalInputTokens > 0 ? (data.totalOutputTokens / data.totalInputTokens).toFixed(2) : 0
     const aiVsHuman = data.totalUserChars > 0 ? (data.totalAssistantChars / data.totalUserChars).toFixed(1) : 0
     return { totalTok, msgsPerSession, toolsPerSession, tokPerMsg, cacheHitRate, outputRatio, aiVsHuman }
@@ -300,14 +300,16 @@ export default function DeepAnalysis({ overview }) {
                 <div>
                   <div className="flex items-center justify-between text-[11px] mb-1">
                     <span style={{ color: 'var(--c-text2)' }}>input tokens</span>
-                    <span className="font-bold" style={{ color: 'var(--c-white)' }}>{formatNumber(data.totalInputTokens + data.totalCacheRead)}</span>
+                    <span className="font-bold" style={{ color: 'var(--c-white)' }}>{formatNumber(data.totalInputTokens + data.totalCacheRead + data.totalCacheWrite)}</span>
                   </div>
                   <ProportionBar segments={[
                     { label: 'Fresh input', value: data.totalInputTokens, color: '#6366f1' },
+                    { label: 'Cache write', value: data.totalCacheWrite, color: '#fbbf24' },
                     { label: 'Cache read', value: data.totalCacheRead, color: '#34d399' },
                   ]} />
                   <div className="flex items-center gap-3 mt-1 text-[10px]">
                     <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-sm" style={{ background: '#6366f1' }} /> fresh {formatNumber(data.totalInputTokens)}</span>
+                    <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-sm" style={{ background: '#fbbf24' }} /> cache write {formatNumber(data.totalCacheWrite)}</span>
                     <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-sm" style={{ background: '#34d399' }} /> cached {formatNumber(data.totalCacheRead)}</span>
                   </div>
                 </div>

--- a/ui/src/pages/DeepAnalysis.jsx
+++ b/ui/src/pages/DeepAnalysis.jsx
@@ -232,7 +232,7 @@ export default function DeepAnalysis({ overview }) {
     const tokPerMsg = data.totalMessages > 0 ? Math.round(totalTok / data.totalMessages) : 0
     const totalInputAll = data.totalInputTokens + data.totalCacheRead + data.totalCacheWrite
     const cacheHitRate = totalInputAll > 0 ? ((data.totalCacheRead / totalInputAll) * 100).toFixed(1) : 0
-    const outputRatio = data.totalInputTokens > 0 ? (data.totalOutputTokens / data.totalInputTokens).toFixed(2) : 0
+    const outputRatio = totalInputAll > 0 ? (data.totalOutputTokens / totalInputAll).toFixed(3) : 0
     const aiVsHuman = data.totalUserChars > 0 ? (data.totalAssistantChars / data.totalUserChars).toFixed(1) : 0
     return { totalTok, msgsPerSession, toolsPerSession, tokPerMsg, cacheHitRate, outputRatio, aiVsHuman }
   }, [data])
@@ -310,7 +310,7 @@ export default function DeepAnalysis({ overview }) {
                   <div className="flex items-center gap-3 mt-1 text-[10px]">
                     <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-sm" style={{ background: '#6366f1' }} /> fresh {formatNumber(data.totalInputTokens)}</span>
                     <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-sm" style={{ background: '#fbbf24' }} /> cache write {formatNumber(data.totalCacheWrite)}</span>
-                    <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-sm" style={{ background: '#34d399' }} /> cached {formatNumber(data.totalCacheRead)}</span>
+                    <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-sm" style={{ background: '#34d399' }} /> cache read {formatNumber(data.totalCacheRead)}</span>
                   </div>
                 </div>
                 {/* Output tokens */}

--- a/ui/src/pages/DeepAnalysis.jsx
+++ b/ui/src/pages/DeepAnalysis.jsx
@@ -226,7 +226,7 @@ export default function DeepAnalysis({ overview }) {
   // Computed insights
   const insights = useMemo(() => {
     if (!data) return null
-    const totalTok = data.totalInputTokens + data.totalOutputTokens
+    const totalTok = data.totalInputTokens + data.totalOutputTokens + data.totalCacheRead + data.totalCacheWrite
     const msgsPerSession = data.analyzedChats > 0 ? (data.totalMessages / data.analyzedChats).toFixed(1) : 0
     const toolsPerSession = data.analyzedChats > 0 ? (data.totalToolCalls / data.analyzedChats).toFixed(1) : 0
     const tokPerMsg = data.totalMessages > 0 ? Math.round(totalTok / data.totalMessages) : 0


### PR DESCRIPTION
## Summary                                                                                                               
  - Fix cache hit rate exceeding 100% (e.g. 1207.2%) by using true total input (fresh + cache read + cache write) as
  denominator
  - Fix negative fresh token count in token flow by using fresh input directly instead of subtracting cache read
  - Include cache write tokens in input tokens total and proportion bar for accurate breakdown
  - Fix total tokens KPI to include cache read and cache write tokens
  - Use cache-inclusive total input as denominator for output/input ratio

Before:
<img width="1377" height="416" alt="Ekran Resmi 2026-03-11 12 04 15" src="https://github.com/user-attachments/assets/29664114-f8f6-40a1-8474-290bcbe492e2" />

After:

<img width="1371" height="404" alt="image" src="https://github.com/user-attachments/assets/106e551b-0cd5-45a9-b4a5-f69c53e76bfe" />
