### PR TITLE
feat: add GSD workflow tracking dashboard

### DIFF
--- a/cache.js
+++ b/cache.js
@@ -7,7 +7,7 @@ const { calculateCost, getModelPricing, normalizeModelName } = require('./pricin
 
 const CACHE_DIR = path.join(os.homedir(), '.agentlytics');
 const CACHE_DB = path.join(CACHE_DIR, 'cache.db');
-const SCHEMA_VERSION = 6; // bump this when schema changes to auto-revalidate
+const SCHEMA_VERSION = 7; // bump this when schema changes to auto-revalidate
 
 /**
  * Normalize a folder path for consistent storage/lookup.
@@ -154,6 +154,38 @@ function initDb() {
     CREATE INDEX IF NOT EXISTS idx_messages_chat ON messages(chat_id);
     CREATE INDEX IF NOT EXISTS idx_tool_calls_name ON tool_calls(tool_name);
     CREATE INDEX IF NOT EXISTS idx_tool_calls_chat ON tool_calls(chat_id);
+
+    CREATE TABLE IF NOT EXISTS gsd_projects (
+      folder TEXT PRIMARY KEY,
+      name TEXT,
+      description TEXT,
+      milestone TEXT,
+      total_phases INTEGER DEFAULT 0,
+      completed_phases INTEGER DEFAULT 0,
+      active_phase TEXT,
+      todos INTEGER DEFAULT 0,
+      backlog INTEGER DEFAULT 0,
+      notes INTEGER DEFAULT 0,
+      last_modified INTEGER,
+      scanned_at INTEGER
+    );
+
+    CREATE TABLE IF NOT EXISTS gsd_phases (
+      id TEXT PRIMARY KEY,
+      folder TEXT NOT NULL,
+      phase_number INTEGER,
+      phase_name TEXT,
+      status TEXT,
+      total_tasks INTEGER DEFAULT 0,
+      completed_tasks INTEGER DEFAULT 0,
+      has_plan INTEGER DEFAULT 0,
+      has_research INTEGER DEFAULT 0,
+      has_verification INTEGER DEFAULT 0,
+      last_modified INTEGER,
+      FOREIGN KEY (folder) REFERENCES gsd_projects(folder)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_gsd_phases_folder ON gsd_phases(folder);
   `);
 
   // Store schema version so future runs can detect mismatches
@@ -357,6 +389,9 @@ function scanAll(onProgress, opts = {}) {
   // Store scan metadata
   db.prepare('INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)').run('last_scan', Date.now().toString());
   db.prepare('INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)').run('total_chats', total.toString());
+
+  // GSD scan
+  cacheGSDProjects();
 
   return { total, analyzed, skipped };
 }
@@ -839,6 +874,9 @@ async function scanAllAsync(onProgress, opts = {}) {
   db.prepare('INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)').run('last_scan', Date.now().toString());
   db.prepare('INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)').run('total_chats', total.toString());
 
+  // GSD scan
+  cacheGSDProjects();
+
   return { total, analyzed, skipped };
 }
 
@@ -1300,6 +1338,156 @@ function getCostAnalytics(opts = {}) {
 
 function getDb() { return db; }
 
+// ============================================================
+// GSD cache functions
+// ============================================================
+
+const gsd = require('./editors/gsd');
+
+function cacheGSDProjects() {
+  // Get all unique known folders from chats table
+  const rows = db.prepare('SELECT DISTINCT folder FROM chats WHERE folder IS NOT NULL').all();
+  const knownFolders = rows.map(r => r.folder);
+
+  const projects = gsd.getGSDProjects(knownFolders);
+
+  const insProject = db.prepare(`
+    INSERT OR REPLACE INTO gsd_projects
+      (folder, name, description, milestone, total_phases, completed_phases, active_phase, todos, backlog, notes, last_modified, scanned_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const delPhases = db.prepare('DELETE FROM gsd_phases WHERE folder = ?');
+  const insPhase = db.prepare(`
+    INSERT OR REPLACE INTO gsd_phases
+      (id, folder, phase_number, phase_name, status, total_tasks, completed_tasks, has_plan, has_research, has_verification, last_modified)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+
+  const tx = db.transaction(() => {
+    for (const p of projects) {
+      insProject.run(
+        p.folder, p.name, p.description, p.milestone,
+        p.totalPhases, p.completedPhases, p.activePhase,
+        p.todos, p.backlog, p.notes,
+        p.lastModified, Date.now()
+      );
+      delPhases.run(p.folder);
+      const phases = gsd.getGSDPhases(p.folder);
+      for (const ph of phases) {
+        const id = `${p.folder}::${ph.phaseDir}`;
+        insPhase.run(
+          id, p.folder, ph.number, ph.name, ph.status,
+          ph.tasks.total, ph.tasks.completed,
+          ph.hasPlan ? 1 : 0,
+          ph.hasResearch ? 1 : 0,
+          ph.hasVerification ? 1 : 0,
+          ph.lastModified
+        );
+      }
+    }
+  });
+  tx();
+}
+
+function getCachedGSDProjects() {
+  const projects = db.prepare('SELECT * FROM gsd_projects ORDER BY last_modified DESC').all();
+  for (const p of projects) {
+    try {
+      const phases = getGSDPhaseTokens(p.folder);
+      p.total_cost = phases.reduce((s, r) => s + (r.cost || 0), 0);
+    } catch {
+      p.total_cost = 0;
+    }
+  }
+  return projects;
+}
+
+function getCachedGSDPhases(folder) {
+  return db.prepare('SELECT * FROM gsd_phases WHERE folder = ? ORDER BY phase_number ASC').all(folder);
+}
+
+function getGSDPhaseTokens(folder) {
+  const phases = db.prepare(
+    'SELECT id, phase_number, phase_name, status, last_modified FROM gsd_phases WHERE folder = ? ORDER BY phase_number ASC'
+  ).all(folder);
+
+  if (phases.length === 0) return [];
+
+  // Sort by last_modified to build sequential non-overlapping time windows.
+  // Phases with no last_modified are placed at the end.
+  const byTime = [...phases]
+    .filter(p => p.last_modified)
+    .sort((a, b) => a.last_modified - b.last_modified);
+
+  const windowMap = new Map();
+  for (let i = 0; i < byTime.length; i++) {
+    const start = i === 0 ? 0 : byTime[i - 1].last_modified;
+    const end = i === byTime.length - 1 ? Date.now() : byTime[i].last_modified;
+    windowMap.set(byTime[i].id, { start, end });
+  }
+
+  const stmt = db.prepare(`
+    SELECT cs.total_input_tokens, cs.total_output_tokens,
+           cs.total_cache_read, cs.total_cache_write, cs.models
+    FROM chats c JOIN chat_stats cs ON cs.chat_id = c.id
+    WHERE c.folder = ? AND COALESCE(c.last_updated_at, c.created_at) BETWEEN ? AND ?
+  `);
+
+  return phases.map(ph => {
+    const win = windowMap.get(ph.id);
+    let totalInput = 0, totalOutput = 0, totalCacheRead = 0, totalCacheWrite = 0;
+    let sessionCount = 0;
+    const modelFreq = {};
+
+    if (win) {
+      const rows = stmt.all(folder, win.start, win.end);
+      for (const row of rows) {
+        totalInput += row.total_input_tokens || 0;
+        totalOutput += row.total_output_tokens || 0;
+        totalCacheRead += row.total_cache_read || 0;
+        totalCacheWrite += row.total_cache_write || 0;
+        sessionCount++;
+        try {
+          const models = JSON.parse(row.models || '[]');
+          for (const m of models) {
+            const key = typeof m === 'string' ? m : (m && m.model);
+            if (key) modelFreq[key] = (modelFreq[key] || 0) + 1;
+          }
+        } catch { /* skip */ }
+      }
+    }
+
+    const dominantModel = Object.entries(modelFreq).sort((a, b) => b[1] - a[1])[0]?.[0] || null;
+    const cost = dominantModel
+      ? (calculateCost(dominantModel, totalInput, totalOutput, totalCacheRead, totalCacheWrite) || 0)
+      : 0;
+    const totalTokens = totalInput + totalOutput;
+
+    return {
+      id: ph.id,
+      phase_number: ph.phase_number,
+      phase_name: ph.phase_name,
+      status: ph.status,
+      total_tokens: totalTokens,
+      cost,
+      session_count: sessionCount,
+    };
+  });
+}
+
+function getCachedGSDOverview() {
+  const projects = getCachedGSDProjects();
+  const totalProjects = projects.length;
+  const totalPhases = projects.reduce((s, p) => s + p.total_phases, 0);
+  const completedPhases = projects.reduce((s, p) => s + p.completed_phases, 0);
+  const activePhases = projects
+    .filter(p => p.active_phase)
+    .map(p => ({ folder: p.folder, name: p.name, activePhase: p.active_phase }));
+  const executingPhases = db.prepare("SELECT COUNT(*) as c FROM gsd_phases WHERE status = 'executing'").get().c;
+  const plannedPhases = db.prepare("SELECT COUNT(*) as c FROM gsd_phases WHERE status = 'planned'").get().c;
+  return { totalProjects, totalPhases, completedPhases, activePhases, executingPhases, plannedPhases };
+}
+
 module.exports = {
   initDb,
   scanAll,
@@ -1317,4 +1505,9 @@ module.exports = {
   getCostBreakdown,
   getCostAnalytics,
   getDb,
+  cacheGSDProjects,
+  getCachedGSDProjects,
+  getCachedGSDPhases,
+  getCachedGSDOverview,
+  getGSDPhaseTokens,
 };

--- a/editors/gsd.js
+++ b/editors/gsd.js
@@ -1,0 +1,366 @@
+const path = require('path');
+const fs = require('fs');
+
+const name = 'gsd';
+const labels = { gsd: 'GSD Workflow' };
+
+// ============================================================
+// Helpers
+// ============================================================
+
+function readFileSafe(filePath) {
+  try { return fs.readFileSync(filePath, 'utf-8'); } catch { return null; }
+}
+
+function statSafe(filePath) {
+  try { return fs.statSync(filePath); } catch { return null; }
+}
+
+function countFiles(dir) {
+  try { return fs.readdirSync(dir).filter(f => !f.startsWith('.')).length; } catch { return 0; }
+}
+
+/**
+ * Parse YAML frontmatter from STATE.md.
+ * Returns { status, milestone, stoppedAt, progress } or null.
+ */
+function parseStateMd(content) {
+  if (!content) return null;
+  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!m) return null;
+  const yaml = m[1];
+  function get(key) {
+    const r = yaml.match(new RegExp(`^${key}:\\s*(.+)`, 'm'));
+    return r ? r[1].trim().replace(/^["']|["']$/g, '') : null;
+  }
+  function getInt(key) { const v = get(key); return v ? parseInt(v) : null; }
+  const progressBlock = yaml.match(/^progress:\s*\n((?:[ \t]+.+\n?)*)/m);
+  let progress = null;
+  if (progressBlock) {
+    const pb = progressBlock[1];
+    function pgGet(key) {
+      const r = pb.match(new RegExp(`${key}:\\s*(\\d+)`));
+      return r ? parseInt(r[1]) : null;
+    }
+    progress = {
+      total_phases: pgGet('total_phases'),
+      completed_phases: pgGet('completed_phases'),
+      total_plans: pgGet('total_plans'),
+      completed_plans: pgGet('completed_plans'),
+    };
+  }
+  return {
+    status: get('status'),
+    milestone: get('milestone'),
+    stoppedAt: get('stopped_at'),
+    lastUpdated: get('last_updated'),
+    progress,
+  };
+}
+
+/**
+ * Parse ROADMAP.md phase checkboxes into a map of phase_number → completed.
+ * Phase lines look like: - [x] **Phase 1: Name** or - [ ] Phase 2: Name
+ */
+function parseRoadmapPhaseStatus(content) {
+  if (!content) return new Map();
+  const statusMap = new Map(); // phase_number (int) → 'completed' | 'planned'
+  for (const line of content.split('\n')) {
+    const cbMatch = line.match(/^[-*]\s+\[([x ])\]\s+(.+)/i);
+    if (!cbMatch) continue;
+    const text = cbMatch[2];
+    if (/\d+-\d+-PLAN\.md/i.test(text) || /PLAN\.md\s*[—–-]/i.test(text)) continue;
+    // Extract phase number from patterns: "Phase 1:", "Phase 01:", "**Phase 2:**"
+    const numMatch = text.match(/phase\s+(\d+)/i);
+    if (!numMatch) continue;
+    const num = parseInt(numMatch[1]);
+    if (!isNaN(num)) {
+      statusMap.set(num, cbMatch[1].toLowerCase() === 'x' ? 'completed' : 'planned');
+    }
+  }
+  return statusMap;
+}
+
+/**
+ * Parse PROJECT.md — first # heading = project name, rest = description.
+ */
+function parseProjectMd(content) {
+  if (!content) return { name: null, description: null };
+  const lines = content.split('\n');
+  let projectName = null;
+  const descLines = [];
+  for (const line of lines) {
+    const h1 = line.match(/^#\s+(.+)/);
+    if (h1 && !projectName) {
+      projectName = h1[1].trim();
+      continue;
+    }
+    if (projectName && line.trim()) descLines.push(line.trim());
+  }
+  return {
+    name: projectName,
+    description: descLines.slice(0, 3).join(' ').substring(0, 300) || null,
+  };
+}
+
+/**
+ * Parse ROADMAP.md for phase completion.
+ * Supports: - [ ] **Phase N: Name** ...  and  - [x] **Phase N: Name** ...
+ * Also supports emoji: ✅ completed, 🚧 in-progress, □ planned
+ */
+function parseRoadmapMd(content) {
+  if (!content) return [];
+  const phases = [];
+  for (const line of content.split('\n')) {
+    // Checkbox style: - [ ] or - [x]
+    // Only count lines that look like phase entries, NOT plan file listings (e.g. "01-01-PLAN.md")
+    const cbMatch = line.match(/^[-*]\s+\[([x ])\]\s+(.+)/i);
+    if (cbMatch) {
+      const text = cbMatch[2];
+      // Skip plan file entries like "01-01-PLAN.md — description"
+      if (/\d+-\d+-PLAN\.md/i.test(text) || /PLAN\.md\s*[—–-]/i.test(text)) continue;
+      phases.push({ text: text.replace(/\*\*/g, '').trim(), completed: cbMatch[1].toLowerCase() === 'x' });
+      continue;
+    }
+    // Emoji style: ✅ completed, 🚧 in-progress (milestone-level)
+    const emojiMatch = line.match(/^[-*]\s+(✅|🚧|⬜|□)\s+(.+)/);
+    if (emojiMatch) {
+      phases.push({ text: emojiMatch[2].replace(/\*\*/g, '').trim(), completed: emojiMatch[1] === '✅' });
+    }
+  }
+  return phases;
+}
+
+/**
+ * Detect the currently active milestone name from ROADMAP.md.
+ * Looks for 🚧 milestone entries or the first uncompleted milestone block.
+ */
+function detectActiveMilestone(content) {
+  if (!content) return null;
+  for (const line of content.split('\n')) {
+    const m = line.match(/🚧\s+\*?\*?([^*\n-]+)/);
+    if (m) return m[1].trim().split(' - ')[0].trim();
+    // Also handle "in progress" text
+    if (/in.progress/i.test(line)) {
+      const nm = line.match(/\*?\*?([vV][\d.]+[^*]*)\*?\*?/);
+      if (nm) return nm[1].trim();
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract phase number prefix from a phase directory name.
+ * e.g. "01-auth-ve-giris" → "01"
+ * e.g. "999.1-backlog-item" → "999.1"
+ */
+function extractPhasePrefix(dirName) {
+  const m = dirName.match(/^(\d+(?:\.\d+)?)-/);
+  return m ? m[1] : null;
+}
+
+/**
+ * Parse checkbox tasks from a PLAN.md file.
+ */
+function parseCheckboxes(content) {
+  if (!content) return { total: 0, completed: 0, tasks: [] };
+  const tasks = [];
+  for (const line of content.split('\n')) {
+    const m = line.match(/^[-*]\s+\[([x ])\]\s+(.+)/i);
+    if (!m) continue;
+    tasks.push({ name: m[2].trim(), completed: m[1].toLowerCase() === 'x' });
+  }
+  return { total: tasks.length, completed: tasks.filter(t => t.completed).length, tasks };
+}
+
+// ============================================================
+// Public API
+// ============================================================
+
+/**
+ * Scan known project folders for GSD .planning/ directories.
+ * Returns project-level summary for each GSD project found.
+ */
+function getGSDProjects(knownFolders) {
+  const results = [];
+
+  for (const folder of knownFolders) {
+    if (!folder) continue;
+    const planningDir = path.join(folder, '.planning');
+    if (!fs.existsSync(planningDir)) continue;
+
+    // Must have at least PROJECT.md or ROADMAP.md to be a GSD project
+    const hasProject = fs.existsSync(path.join(planningDir, 'PROJECT.md'));
+    const hasRoadmap = fs.existsSync(path.join(planningDir, 'ROADMAP.md'));
+    if (!hasProject && !hasRoadmap) continue;
+
+    const projectContent = readFileSafe(path.join(planningDir, 'PROJECT.md'));
+    const roadmapContent = readFileSafe(path.join(planningDir, 'ROADMAP.md'));
+    const stateContent = readFileSafe(path.join(planningDir, 'STATE.md'));
+    const stateData = parseStateMd(stateContent);
+
+    const { name: projectName, description } = parseProjectMd(projectContent);
+
+    // Use filesystem as source of truth for phase counts
+    // Filter out malformed directory names (e.g. dirs with JSON content in name)
+    const phases = getGSDPhases(folder, roadmapContent);
+    const validPhases = phases.filter(ph => ph.number !== null);
+
+    const totalPhases = validPhases.length;
+    const completedPhases = validPhases.filter(p => p.status === 'completed').length;
+    const firstIncomplete = validPhases.find(p => p.status !== 'completed');
+    const activePhase = stateData?.stoppedAt || (firstIncomplete ? firstIncomplete.name : null);
+
+    // Prefer STATE.md milestone, fallback to ROADMAP detection
+    const activeMilestone = stateData?.milestone || detectActiveMilestone(roadmapContent);
+
+    // Count todos/seeds/quick (common GSD directories)
+    const todos = countFiles(path.join(planningDir, 'todos'))
+      + countFiles(path.join(planningDir, 'seeds'));
+    const notes = countFiles(path.join(planningDir, 'quick'));
+    const backlog = countFiles(path.join(planningDir, 'backlog'));
+
+    const planStat = statSafe(planningDir);
+    const lastModified = planStat ? Math.round(planStat.mtimeMs) : null;
+
+    results.push({
+      folder,
+      name: projectName || path.basename(folder),
+      description,
+      milestone: activeMilestone,
+      totalPhases,
+      completedPhases,
+      activePhase,
+      todos,
+      backlog,
+      notes,
+      lastModified,
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Return phase details for a single GSD project.
+ * Phases live in .planning/phases/<phaseDir>/
+ * roadmapContent is optionally passed to cross-reference checkbox status.
+ */
+function getGSDPhases(folder, roadmapContent) {
+  if (roadmapContent === undefined) {
+    roadmapContent = readFileSafe(path.join(folder, '.planning', 'ROADMAP.md'));
+  }
+  const roadmapStatus = parseRoadmapPhaseStatus(roadmapContent);
+  const phasesDir = path.join(folder, '.planning', 'phases');
+  let phaseDirs;
+  try {
+    phaseDirs = fs.readdirSync(phasesDir)
+      .filter(f => {
+        try { return fs.statSync(path.join(phasesDir, f)).isDirectory(); } catch { return false; }
+      })
+      .sort((a, b) => {
+        // Sort by numeric prefix (supports decimals like 999.1)
+        const na = parseFloat(extractPhasePrefix(a) || '9999');
+        const nb = parseFloat(extractPhasePrefix(b) || '9999');
+        return na - nb;
+      });
+  } catch { return []; }
+
+  const phases = [];
+  for (const phaseDir of phaseDirs) {
+    const phaseFullDir = path.join(phasesDir, phaseDir);
+    const prefix = extractPhasePrefix(phaseDir);
+
+    // Phase name: everything after the leading number prefix
+    const nameRaw = phaseDir.replace(/^\d+(?:\.\d+)?-/, '').replace(/-/g, ' ');
+    const phaseName = nameRaw.length > 0 ? nameRaw : phaseDir;
+
+    // Phase number (numeric value for display)
+    const phaseNumber = prefix ? parseFloat(prefix) : null;
+
+    // Detect artifact files using the phase prefix pattern
+    let hasPlan = false, hasResearch = false, hasVerification = false;
+    let planCount = 0, summaryCount = 0;
+    let latestMtime = 0;
+
+    try {
+      const files = fs.readdirSync(phaseFullDir);
+      for (const f of files) {
+        const fPath = path.join(phaseFullDir, f);
+        const st = statSafe(fPath);
+        if (st && st.mtimeMs > latestMtime) latestMtime = st.mtimeMs;
+
+        // PLAN files: {prefix}-{n}-PLAN.md
+        if (f.match(/PLAN\.md$/i)) { hasPlan = true; planCount++; }
+        // SUMMARY files: indicates a plan was executed
+        if (f.match(/SUMMARY\.md$/i)) summaryCount++;
+        // VERIFICATION
+        if (f.match(/VERIFICATION\.md$/i)) hasVerification = true;
+        // RESEARCH
+        if (f.match(/RESEARCH\.md$/i)) hasResearch = true;
+      }
+    } catch { /* skip */ }
+
+    // Determine status: file-based first, then cross-reference ROADMAP.md checkboxes
+    let status = 'planned';
+    if (hasVerification) {
+      status = 'completed';
+    } else if (roadmapStatus.get(phaseNumber) === 'completed') {
+      // ROADMAP.md marks this phase [x] even without VERIFICATION.md
+      status = 'completed';
+    } else if (summaryCount > 0) {
+      status = 'executing';
+    } else if (hasPlan) {
+      status = 'planned';
+    }
+
+    phases.push({
+      phaseDir,
+      number: phaseNumber,
+      name: phaseName,
+      status,
+      tasks: { total: planCount, completed: summaryCount },
+      hasVerification,
+      hasPlan,
+      hasResearch,
+      lastModified: latestMtime || null,
+    });
+  }
+
+  return phases;
+}
+
+/**
+ * Return combined PLAN.md content for a phase.
+ * Aggregates all *-PLAN.md files in order.
+ */
+function getGSDPlanDetail(folder, phaseDir) {
+  const phaseFullDir = path.join(folder, '.planning', 'phases', phaseDir);
+  if (!fs.existsSync(phaseFullDir)) return null;
+
+  let files;
+  try { files = fs.readdirSync(phaseFullDir).filter(f => f.match(/PLAN\.md$/i)).sort(); }
+  catch { return null; }
+  if (files.length === 0) return null;
+
+  const sections = [];
+  const allTasks = [];
+
+  for (const f of files) {
+    const content = readFileSafe(path.join(phaseFullDir, f));
+    if (!content) continue;
+    sections.push(`## ${f}\n\n${content}`);
+    const { tasks } = parseCheckboxes(content);
+    allTasks.push(...tasks);
+  }
+
+  return { content: sections.join('\n\n---\n\n'), tasks: allTasks };
+}
+
+module.exports = {
+  name,
+  labels,
+  getGSDProjects,
+  getGSDPhases,
+  getGSDPlanDetail,
+};

--- a/server.js
+++ b/server.js
@@ -727,6 +727,108 @@ app.get('/api/all-projects', (req, res) => {
   }
 });
 
+// ============================================================
+// GSD endpoints
+// ============================================================
+
+app.get('/api/gsd/projects', (req, res) => {
+  try {
+    res.json(cache.getCachedGSDProjects());
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/api/gsd/phases', (req, res) => {
+  try {
+    const { folder } = req.query;
+    if (!folder) return res.status(400).json({ error: 'folder query param required' });
+    res.json(cache.getCachedGSDPhases(folder));
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/api/gsd/plan', (req, res) => {
+  try {
+    const { folder, phase } = req.query;
+    if (!folder || !phase) return res.status(400).json({ error: 'folder and phase query params required' });
+    const gsd = require('./editors/gsd');
+    const detail = gsd.getGSDPlanDetail(folder, phase);
+    if (!detail) return res.status(404).json({ error: 'Plan not found' });
+    res.json(detail);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/api/gsd/overview', (req, res) => {
+  try {
+    res.json(cache.getCachedGSDOverview());
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/api/gsd/config', (req, res) => {
+  try {
+    const { folder } = req.query;
+    if (!folder) return res.status(400).json({ error: 'folder query param required' });
+    const configPath = require('path').join(folder, '.planning', 'config.json');
+    if (!fs.existsSync(configPath)) return res.json(null);
+    res.json(JSON.parse(fs.readFileSync(configPath, 'utf-8')));
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/api/gsd/phase-tokens', (req, res) => {
+  try {
+    const { folder } = req.query;
+    if (!folder) return res.status(400).json({ error: 'folder query param required' });
+    res.json(cache.getGSDPhaseTokens(folder));
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Generic .planning file reader
+// type: 'state' (project-level STATE.md) | 'research' | 'verification' | 'summary' (phase-level, requires phase param)
+app.get('/api/gsd/file', (req, res) => {
+  try {
+    const { folder, phase: phaseDir, type } = req.query;
+    if (!folder || !type) return res.status(400).json({ error: 'folder and type required' });
+
+    const planningDir = path.join(folder, '.planning');
+    let content = null;
+
+    if (type === 'state') {
+      const filePath = path.join(planningDir, 'STATE.md');
+      if (fs.existsSync(filePath)) content = fs.readFileSync(filePath, 'utf-8');
+    } else if (phaseDir) {
+      const phaseFullDir = path.join(planningDir, 'phases', phaseDir);
+      const pattern = type === 'research' ? /RESEARCH\.md$/i
+        : type === 'verification' ? /VERIFICATION\.md$/i
+        : type === 'summary' ? /SUMMARY\.md$/i
+        : null;
+      if (pattern && fs.existsSync(phaseFullDir)) {
+        const files = fs.readdirSync(phaseFullDir).filter(f => pattern.test(f)).sort();
+        if (files.length > 0) {
+          const sections = files.map(f => {
+            const c = fs.readFileSync(path.join(phaseFullDir, f), 'utf-8');
+            return files.length > 1 ? `## ${f}\n\n${c}` : c;
+          });
+          content = sections.join('\n\n---\n\n');
+        }
+      }
+    }
+
+    res.json({ content });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // SPA fallback
 app.get('*', (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'index.html'));

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { Routes, Route, NavLink, useLocation } from 'react-router-dom'
-import { Activity, BarChart3, GitCompare, MessageSquare, FolderOpen, DollarSign, CreditCard, Sun, Moon, RefreshCw, AlertTriangle, Github, Terminal, Database, Users, Plug, Copy, Check, Settings as SettingsIcon, Package, ChevronDown } from 'lucide-react'
+import { Activity, BarChart3, GitCompare, MessageSquare, FolderOpen, DollarSign, CreditCard, Sun, Moon, RefreshCw, AlertTriangle, Github, Terminal, Database, Users, Plug, Copy, Check, Settings as SettingsIcon, Package, ChevronDown, Target } from 'lucide-react'
 import { fetchOverview, refetchAgents, fetchMode, fetchRelayConfig, getAuthToken, setOnAuthFailure } from './lib/api'
 import { useTheme } from './lib/theme'
 import { useLive } from './hooks/useLive'
@@ -21,6 +21,7 @@ import Subscriptions from './pages/Subscriptions'
 import MCPs from './pages/MCPs'
 import RelayDashboard from './pages/RelayDashboard'
 import RelayUserDetail from './pages/RelayUserDetail'
+import GSD from './pages/GSD'
 
 function NavDropdown({ icon: Icon, label, items }) {
   const [open, setOpen] = useState(false)
@@ -154,6 +155,7 @@ export default function App() {
       { to: '/compare', icon: GitCompare, label: 'Compare' },
     ]},
     { to: '/artifacts', icon: Package, label: 'Artifacts' },
+    { to: '/gsd', icon: Target, label: 'GSD' },
     { to: '/mcps', icon: Plug, label: 'MCPs' },
     { to: '/sql', icon: Database, label: 'SQL' },
   ]
@@ -284,6 +286,7 @@ export default function App() {
             <Route path="/artifacts" element={<Artifacts />} />
             <Route path="/mcps" element={<MCPs />} />
             <Route path="/sql" element={<SqlViewer />} />
+            <Route path="/gsd" element={<GSD />} />
             <Route path="/settings" element={<Settings />} />
           </Routes>
         )}

--- a/ui/src/lib/api.js
+++ b/ui/src/lib/api.js
@@ -234,6 +234,49 @@ export async function fetchMCPs() {
   return res.json();
 }
 
+// ── GSD API ──
+
+export async function fetchGSDProjects() {
+  const res = await fetch(`${BASE}/api/gsd/projects`);
+  return res.json();
+}
+
+export async function fetchGSDPhases(folder) {
+  const q = new URLSearchParams({ folder });
+  const res = await fetch(`${BASE}/api/gsd/phases?${q}`);
+  return res.json();
+}
+
+export async function fetchGSDPlan(folder, phase) {
+  const q = new URLSearchParams({ folder, phase });
+  const res = await fetch(`${BASE}/api/gsd/plan?${q}`);
+  return res.json();
+}
+
+export async function fetchGSDOverview() {
+  const res = await fetch(`${BASE}/api/gsd/overview`);
+  return res.json();
+}
+
+export async function fetchGSDConfig(folder) {
+  const q = new URLSearchParams({ folder });
+  const res = await fetch(`${BASE}/api/gsd/config?${q}`);
+  return res.json();
+}
+
+export async function fetchGSDPhaseTokens(folder) {
+  const q = new URLSearchParams({ folder });
+  const res = await fetch(`${BASE}/api/gsd/phase-tokens?${q}`);
+  return res.json();
+}
+
+export async function fetchGSDFile(folder, type, phaseDir) {
+  const q = new URLSearchParams({ folder, type });
+  if (phaseDir) q.set('phase', phaseDir);
+  const res = await fetch(`${BASE}/api/gsd/file?${q}`);
+  return res.json();
+}
+
 // ── Relay API ──
 
 export async function fetchMode() {

--- a/ui/src/pages/GSD.jsx
+++ b/ui/src/pages/GSD.jsx
@@ -1,0 +1,726 @@
+import { useState, useEffect, useRef } from 'react'
+import { Chart as ChartJS, ArcElement, Tooltip, Legend, CategoryScale, LinearScale, BarElement } from 'chart.js'
+import { Doughnut, Bar } from 'react-chartjs-2'
+import { Target, FileText, BookOpen, ShieldCheck, ChevronDown, ChevronRight, ListTodo, StickyNote, X, CheckCircle2, Circle, Loader2, HelpCircle, Layers } from 'lucide-react'
+import { fetchGSDProjects, fetchGSDPhases, fetchGSDPlan, fetchGSDOverview, fetchGSDConfig, fetchGSDFile, fetchGSDPhaseTokens } from '../lib/api'
+import { formatCost } from '../lib/constants'
+import AnimatedLoader from '../components/AnimatedLoader'
+import KpiCard from '../components/KpiCard'
+import SectionTitle from '../components/SectionTitle'
+import PageHeader from '../components/PageHeader'
+import { useTheme } from '../lib/theme'
+
+ChartJS.register(ArcElement, Tooltip, Legend, CategoryScale, LinearScale, BarElement)
+
+const MONO = 'JetBrains Mono, monospace'
+
+function formatRelativeTime(ms) {
+  if (!ms) return '—'
+  const diff = Date.now() - ms
+  const m = Math.floor(diff / 60000)
+  if (m < 1) return 'just now'
+  if (m < 60) return `${m}m ago`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h ago`
+  const d = Math.floor(h / 24)
+  return `${d}d ago`
+}
+
+function statusColor(status) {
+  if (status === 'completed') return '#22c55e'
+  if (status === 'executing') return '#f59e0b'
+  return 'var(--c-text3)'
+}
+
+function ProgressBar({ value, total, color = '#6366f1' }) {
+  const pct = total > 0 ? Math.round((value / total) * 100) : 0
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex-1 h-1 rounded-full overflow-hidden" style={{ background: 'var(--c-bg3)' }}>
+        <div className="h-full rounded-full transition-all" style={{ width: `${pct}%`, background: color }} />
+      </div>
+      <span className="text-[10px] tabular-nums" style={{ color: 'var(--c-text3)', fontFamily: MONO, minWidth: 36 }}>
+        {value}/{total}
+      </span>
+    </div>
+  )
+}
+
+// ============================================================
+// File sidebar (slide from right — generic markdown viewer)
+// ============================================================
+
+function FileSidebar({ title, subtitle, content, loading, onClose }) {
+  const scrollRef = useRef(null)
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-40 transition-opacity"
+        style={{ background: 'rgba(0,0,0,0.3)' }}
+        onClick={onClose}
+      />
+      <div
+        className="fixed top-0 right-0 bottom-0 z-50 flex flex-col shadow-2xl sidebar-slide-in cursor-default"
+        style={{ width: 'min(620px, 92vw)', background: 'var(--c-bg)', borderLeft: '1px solid var(--c-border)' }}
+      >
+        {/* Header */}
+        <div className="flex items-center gap-3 px-4 py-3 shrink-0" style={{ borderBottom: '1px solid var(--c-border)' }}>
+          <button onClick={onClose} className="p-1 rounded transition hover:bg-[var(--c-bg3)]" style={{ color: 'var(--c-text2)' }}>
+            <X size={14} />
+          </button>
+          <div className="flex-1 min-w-0">
+            <div className="text-[13px] font-semibold" style={{ color: 'var(--c-white)' }}>{title}</div>
+            {subtitle && (
+              <div className="text-[11px] capitalize" style={{ color: 'var(--c-text2)', fontFamily: MONO }}>{subtitle}</div>
+            )}
+          </div>
+        </div>
+
+        {/* Content */}
+        <div ref={scrollRef} className="flex-1 overflow-y-auto scrollbar-thin px-4 py-3">
+          {loading && (
+            <div className="text-[12px] py-12 text-center" style={{ color: 'var(--c-text3)' }}>Loading…</div>
+          )}
+          {!loading && content === null && (
+            <div className="text-[12px] py-12 text-center" style={{ color: 'var(--c-text3)' }}>File not found.</div>
+          )}
+          {!loading && content !== null && (
+            <pre
+              className="text-[11px] leading-relaxed whitespace-pre-wrap break-words"
+              style={{ color: 'var(--c-text)', fontFamily: MONO }}
+            >
+              {content}
+            </pre>
+          )}
+        </div>
+      </div>
+    </>
+  )
+}
+
+// ============================================================
+// Config popover
+// ============================================================
+
+const CONFIG_LABELS = {
+  mode: 'Mode',
+  model_profile: 'Model profile',
+  granularity: 'Granularity',
+  parallelization: 'Parallelization',
+  commit_docs: 'Commit docs',
+}
+
+const WORKFLOW_LABELS = {
+  research: 'Research',
+  plan_check: 'Plan check',
+  verifier: 'Verifier',
+  nyquist_validation: 'Nyquist',
+  auto_advance: 'Auto advance',
+  ui_phase: 'UI phase',
+  skip_discuss: 'Skip discuss',
+}
+
+function ConfigPopover({ folder, anchor, onClose }) {
+  const [config, setConfig] = useState(undefined)
+  const ref = useRef(null)
+
+  useEffect(() => {
+    fetchGSDConfig(folder).then(setConfig).catch(() => setConfig(null))
+  }, [folder])
+
+  useEffect(() => {
+    function handleClick(e) {
+      if (ref.current && !ref.current.contains(e.target)) onClose()
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [onClose])
+
+  // Position fixed relative to the anchor button rect
+  const top = anchor ? anchor.bottom + 6 : 0
+  const right = anchor ? window.innerWidth - anchor.right : 0
+
+  function val(v) {
+    if (v === true) return <span style={{ color: '#22c55e' }}>on</span>
+    if (v === false) return <span style={{ color: 'var(--c-text3)' }}>off</span>
+    return <span style={{ color: 'var(--c-white)' }}>{String(v)}</span>
+  }
+
+  return (
+    <div
+      ref={ref}
+      className="p-3 shadow-xl text-[11px]"
+      style={{
+        position: 'fixed',
+        top,
+        right,
+        zIndex: 9999,
+        width: 240,
+        background: 'var(--c-bg)',
+        border: '1px solid var(--c-border)',
+        boxShadow: '0 8px 32px rgba(0,0,0,0.4)',
+      }}
+      onClick={e => e.stopPropagation()}
+    >
+      {config === undefined && (
+        <div style={{ color: 'var(--c-text3)' }}>Loading…</div>
+      )}
+      {config === null && (
+        <div style={{ color: 'var(--c-text3)' }}>No config.json found.</div>
+      )}
+      {config && (
+        <div className="space-y-2">
+          {/* Top-level settings */}
+          <div className="space-y-1">
+            {Object.entries(CONFIG_LABELS).map(([k, label]) => {
+              if (!(k in config)) return null
+              return (
+                <div key={k} className="flex items-center justify-between gap-2">
+                  <span style={{ color: 'var(--c-text2)' }}>{label}</span>
+                  {val(config[k])}
+                </div>
+              )
+            })}
+          </div>
+          {/* Workflow toggles */}
+          {config.workflow && (
+            <>
+              <div className="border-t pt-2" style={{ borderColor: 'var(--c-border)', color: 'var(--c-text3)' }}>workflow</div>
+              <div className="grid grid-cols-2 gap-x-3 gap-y-1">
+                {Object.entries(WORKFLOW_LABELS).map(([k, label]) => {
+                  if (!(k in config.workflow)) return null
+                  return (
+                    <div key={k} className="flex items-center justify-between gap-1">
+                      <span style={{ color: 'var(--c-text2)' }}>{label}</span>
+                      {val(config.workflow[k])}
+                    </div>
+                  )
+                })}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ============================================================
+// Phase row
+// ============================================================
+
+function PhaseRow({ phase, tokenData, onOpenFile }) {
+  // Phase comes from SQLite cache — flat fields (total_tasks, completed_tasks, has_plan, etc.)
+  const totalTasks = phase.total_tasks ?? 0
+  const completedTasks = phase.completed_tasks ?? 0
+  const hasPlan = !!phase.has_plan
+  const hasResearch = !!phase.has_research
+  const hasVerification = !!phase.has_verification
+  const status = phase.status ?? 'planned'
+
+  const StatusIcon = status === 'completed'
+    ? CheckCircle2
+    : status === 'executing'
+      ? Loader2
+      : Circle
+
+  return (
+    <div
+      className="flex items-center px-3 py-2 border-b text-[12px] hover:bg-[var(--c-bg3)] transition"
+      style={{ borderColor: 'var(--c-border)', gap: 0 }}
+    >
+      {/* Status icon — 28px */}
+      <div style={{ width: 28, flexShrink: 0 }}>
+        <StatusIcon
+          size={12}
+          style={{ color: statusColor(status) }}
+          className={status === 'executing' ? 'animate-spin' : ''}
+        />
+      </div>
+
+      {/* Phase number — 32px */}
+      <div style={{ width: 32, flexShrink: 0 }}>
+        <span className="text-[10px] font-bold tabular-nums" style={{ color: 'var(--c-text3)', fontFamily: MONO }}>
+          {phase.phase_number ?? '?'}
+        </span>
+      </div>
+
+      {/* Phase name — flex-1 */}
+      <div className="flex-1 min-w-0 pr-3">
+        <span className="block truncate capitalize text-[12px]" style={{ color: 'var(--c-white)' }}>
+          {phase.phase_name}
+        </span>
+      </div>
+
+      {/* Progress bar — always 100px */}
+      <div style={{ width: 100, flexShrink: 0, paddingRight: 12 }}>
+        {totalTasks > 0
+          ? <ProgressBar value={completedTasks} total={totalTasks} color={statusColor(status)} />
+          : null}
+      </div>
+
+      {/* Artifacts — always 88px */}
+      <div style={{ width: 88, flexShrink: 0 }} className="flex items-center gap-1">
+        {hasPlan && (
+          <button
+            onClick={() => onOpenFile(phase, 'plan')}
+            className="flex items-center gap-1 px-1.5 py-px text-[10px] transition hover:opacity-80 cursor-pointer"
+            style={{ background: 'rgba(99,102,241,0.12)', color: '#818cf8' }}
+            title="View PLAN.md"
+          >
+            <FileText size={9} />
+            plan
+          </button>
+        )}
+        {hasResearch && (
+          <button
+            onClick={() => onOpenFile(phase, 'research')}
+            className="px-1 py-px transition hover:opacity-80 cursor-pointer"
+            style={{ background: 'rgba(245,158,11,0.1)', color: '#f59e0b' }}
+            title="View RESEARCH.md"
+          >
+            <BookOpen size={9} />
+          </button>
+        )}
+        {hasVerification && (
+          <button
+            onClick={() => onOpenFile(phase, 'verification')}
+            className="px-1 py-px transition hover:opacity-80 cursor-pointer"
+            style={{ background: 'rgba(34,197,94,0.1)', color: '#22c55e' }}
+            title="View VERIFICATION.md"
+          >
+            <ShieldCheck size={9} />
+          </button>
+        )}
+      </div>
+
+      {/* Est. cost — always 64px */}
+      <div style={{ width: 64, flexShrink: 0, textAlign: 'right' }}>
+        {tokenData && tokenData.cost > 0 ? (
+          <span className="text-[10px] tabular-nums" style={{ color: 'var(--c-text2)', fontFamily: MONO }}>
+            {formatCost(tokenData.cost)}
+          </span>
+        ) : null}
+      </div>
+
+      {/* Time — always 56px */}
+      <div style={{ width: 56, flexShrink: 0, textAlign: 'right' }}>
+        <span className="text-[10px]" style={{ color: 'var(--c-text3)' }}>
+          {formatRelativeTime(phase.last_modified)}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+// ============================================================
+// Project card
+// ============================================================
+
+function projectBorderColor(project) {
+  if (project.total_phases === 0) return 'var(--c-border)'
+  if (project.completed_phases === project.total_phases) return '#22c55e'
+  if (project.completed_phases > 0) return '#f59e0b'
+  return 'var(--c-border)'
+}
+
+function ProjectCard({ project, isExpanded, onToggle, onOpenFile, onOpenConfig, onOpenState }) {
+  const [phases, setPhases] = useState(null)
+  const [tokenMap, setTokenMap] = useState(null) // phase id → token data
+  const configBtnRef = useRef(null)
+  const stateBtnRef = useRef(null)
+  const pct = project.total_phases > 0
+    ? Math.round((project.completed_phases / project.total_phases) * 100)
+    : 0
+  const remaining = project.total_phases - project.completed_phases
+
+  useEffect(() => {
+    if (isExpanded && phases === null) {
+      fetchGSDPhases(project.folder).then(setPhases)
+      fetchGSDPhaseTokens(project.folder).then(rows => {
+        const map = {}
+        for (const r of rows) map[r.id] = r
+        setTokenMap(map)
+      }).catch(() => setTokenMap({}))
+    }
+  }, [isExpanded, phases, project.folder])
+
+  return (
+    <div
+      className="card overflow-hidden"
+      style={{ borderLeft: `2px solid ${projectBorderColor(project)}` }}
+    >
+      <div className="flex items-center w-full px-3 py-3" style={{ gap: 0 }}>
+        {/* Chevron — 24px */}
+        <button
+          onClick={onToggle}
+          className="flex items-center justify-center hover:bg-[var(--c-bg3)] transition rounded cursor-pointer"
+          style={{ width: 24, height: 24, flexShrink: 0, color: 'var(--c-text3)' }}
+        >
+          {isExpanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+        </button>
+
+        {/* Name — flex-1, clickable */}
+        <button
+          onClick={onToggle}
+          className="flex-1 min-w-0 text-left px-2 cursor-pointer"
+        >
+          <div className="flex items-center gap-2">
+            <span className="text-[13px] font-semibold truncate" style={{ color: 'var(--c-white)' }}>
+              {project.name}
+            </span>
+            {project.milestone && (
+              <span className="text-[10px] px-1.5 py-px shrink-0" style={{ background: 'rgba(99,102,241,0.12)', color: '#818cf8' }}>
+                {project.milestone}
+              </span>
+            )}
+          </div>
+          <div className="text-[10px] truncate mt-0.5" style={{ color: 'var(--c-text3)', fontFamily: MONO }}>
+            {project.folder}
+          </div>
+        </button>
+
+        {/* % — 36px */}
+        <div style={{ width: 36, flexShrink: 0, textAlign: 'right' }}>
+          <span
+            className="text-[11px] font-bold tabular-nums"
+            style={{ color: pct === 100 ? '#22c55e' : pct > 0 ? '#f59e0b' : 'var(--c-text3)', fontFamily: MONO }}
+          >
+            {pct}%
+          </span>
+        </div>
+
+        {/* Progress bar — 112px */}
+        <div style={{ width: 112, flexShrink: 0, padding: '0 10px' }}>
+          <ProgressBar
+            value={project.completed_phases}
+            total={project.total_phases}
+            color={pct === 100 ? '#22c55e' : '#6366f1'}
+          />
+        </div>
+
+        {/* Status pills — 80px */}
+        <div style={{ width: 80, flexShrink: 0 }} className="flex items-center gap-1">
+          {project.completed_phases > 0 && (
+            <span className="flex items-center gap-1 text-[10px] px-1.5 py-px" style={{ background: 'rgba(34,197,94,0.08)', color: '#22c55e' }}>
+              <CheckCircle2 size={9} /> {project.completed_phases}
+            </span>
+          )}
+          {remaining > 0 && (
+            <span className="flex items-center gap-1 text-[10px] px-1.5 py-px" style={{ background: 'rgba(255,255,255,0.04)', color: 'var(--c-text3)' }}>
+              <Circle size={9} /> {remaining}
+            </span>
+          )}
+        </div>
+
+        {/* Counters — 52px */}
+        <div style={{ width: 52, flexShrink: 0 }} className="flex items-center gap-2">
+          {project.todos > 0 && (
+            <span className="flex items-center gap-1 text-[10px]" style={{ color: 'var(--c-text3)' }} title="Todos / Seeds">
+              <ListTodo size={10} /> {project.todos}
+            </span>
+          )}
+          {project.notes > 0 && (
+            <span className="flex items-center gap-1 text-[10px]" style={{ color: 'var(--c-text3)' }} title="Quick tasks">
+              <StickyNote size={10} /> {project.notes}
+            </span>
+          )}
+        </div>
+
+        {/* Est. cost — 60px */}
+        <div style={{ width: 60, flexShrink: 0, textAlign: 'right' }}>
+          <span className="text-[11px] tabular-nums" style={{ color: project.total_cost > 0 ? '#a78bfa' : 'var(--c-text3)', fontFamily: MONO }}>
+            {project.total_cost > 0 ? formatCost(project.total_cost) : '—'}
+          </span>
+        </div>
+
+        {/* Updated — 56px */}
+        <div style={{ width: 56, flexShrink: 0, textAlign: 'right' }}>
+          <span className="text-[10px]" style={{ color: 'var(--c-text3)' }}>
+            {formatRelativeTime(project.last_modified)}
+          </span>
+        </div>
+
+        {/* State + Config buttons — 52px */}
+        <div style={{ width: 52, flexShrink: 0 }} className="flex items-center justify-end gap-0.5" onClick={e => e.stopPropagation()}>
+          <button
+            ref={stateBtnRef}
+            onClick={() => onOpenState(project.folder, project.name)}
+            className="p-1 rounded transition hover:bg-[var(--c-bg3)] cursor-pointer"
+            style={{ color: 'var(--c-text3)' }}
+            title="View STATE.md"
+          >
+            <Layers size={13} />
+          </button>
+          <button
+            ref={configBtnRef}
+            onClick={() => onOpenConfig(project.folder, configBtnRef.current?.getBoundingClientRect())}
+            className="p-1 rounded transition hover:bg-[var(--c-bg3)] cursor-pointer"
+            style={{ color: 'var(--c-text3)' }}
+            title="GSD config"
+          >
+            <HelpCircle size={13} />
+          </button>
+        </div>
+      </div>
+
+      {isExpanded && (
+        <div className="border-t" style={{ borderColor: 'var(--c-border)' }}>
+          <div
+            className="flex items-center px-3 py-1 text-[10px]"
+            style={{ background: 'var(--c-bg2)', color: 'var(--c-text3)', gap: 0 }}
+          >
+            <div style={{ width: 28, flexShrink: 0 }} />
+            <div style={{ width: 32, flexShrink: 0 }}>#</div>
+            <div className="flex-1 pr-3">phase</div>
+            <div style={{ width: 100, flexShrink: 0, paddingRight: 12 }}>plans</div>
+            <div style={{ width: 88, flexShrink: 0 }}>artifacts</div>
+            <div style={{ width: 64, flexShrink: 0, textAlign: 'right' }}>est. cost</div>
+            <div style={{ width: 56, flexShrink: 0, textAlign: 'right' }}>updated</div>
+          </div>
+
+          {phases === null
+            ? <div className="px-4 py-3 text-[12px]" style={{ color: 'var(--c-text3)' }}>Loading phases…</div>
+            : phases.length === 0
+              ? <div className="px-4 py-3 text-[12px]" style={{ color: 'var(--c-text3)' }}>No phases found.</div>
+              : phases.map(phase => (
+                <PhaseRow
+                  key={phase.id}
+                  phase={phase}
+                  tokenData={tokenMap?.[phase.id] ?? null}
+                  onOpenFile={(ph, type) => onOpenFile(ph, project.folder, type)}
+                />
+              ))
+          }
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ============================================================
+// Main page
+// ============================================================
+
+export default function GSD() {
+  const { dark } = useTheme()
+  const [projects, setProjects] = useState(null)
+  const [overview, setOverview] = useState(null)
+  const [allTokens, setAllTokens] = useState(null) // { totalCost }
+  const [expandedFolder, setExpandedFolder] = useState(null)
+  const [fileSidebar, setFileSidebar] = useState(null) // { title, subtitle, content, loading }
+  const [configPopover, setConfigPopover] = useState(null) // { folder, anchor }
+  const [loading, setLoading] = useState(true)
+
+  const txtColor = dark ? '#888' : '#555'
+  const txtDim = dark ? '#555' : '#999'
+  const gridColor = dark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.06)'
+
+  useEffect(() => {
+    Promise.all([fetchGSDProjects(), fetchGSDOverview()])
+      .then(([p, o]) => {
+        setProjects(p)
+        setOverview(o)
+        setLoading(false)
+        // total_cost is already computed server-side per project
+        const totalCost = (p || []).reduce((s, proj) => s + (proj.total_cost || 0), 0)
+        setAllTokens({ totalCost })
+      })
+      .catch(() => setLoading(false))
+  }, [])
+
+  function handleOpenConfig(folder, anchor) {
+    setConfigPopover(prev => prev?.folder === folder ? null : { folder, anchor })
+  }
+
+  function handleOpenFile(phase, folder, type) {
+    const phaseDir = phase.id?.split('::')?.[1] || ''
+    const phaseName = phase.phase_name ?? phase.name ?? ''
+    const titles = { plan: 'PLAN.md', research: 'RESEARCH.md', verification: 'VERIFICATION.md', summary: 'SUMMARY.md' }
+    const title = titles[type] ?? type.toUpperCase() + '.md'
+
+    setFileSidebar({ title, subtitle: phaseName, content: null, loading: true })
+
+    if (type === 'plan') {
+      fetchGSDPlan(folder, phaseDir)
+        .then(d => setFileSidebar(prev => prev ? { ...prev, content: d?.content ?? null, loading: false } : null))
+        .catch(() => setFileSidebar(prev => prev ? { ...prev, loading: false } : null))
+    } else {
+      fetchGSDFile(folder, type, phaseDir)
+        .then(d => setFileSidebar(prev => prev ? { ...prev, content: d?.content ?? null, loading: false } : null))
+        .catch(() => setFileSidebar(prev => prev ? { ...prev, loading: false } : null))
+    }
+  }
+
+  function handleOpenState(folder, projectName) {
+    setFileSidebar({ title: 'STATE.md', subtitle: projectName, content: null, loading: true })
+    fetchGSDFile(folder, 'state')
+      .then(d => setFileSidebar(prev => prev ? { ...prev, content: d?.content ?? null, loading: false } : null))
+      .catch(() => setFileSidebar(prev => prev ? { ...prev, loading: false } : null))
+  }
+
+  if (loading) return <AnimatedLoader label="Loading GSD projects..." />
+
+  if (!projects || projects.length === 0) {
+    return (
+      <div className="fade-in space-y-3">
+        <PageHeader icon={Target} title="GSD Workflow" />
+        <div className="card p-8 text-center space-y-3">
+          <Target size={32} style={{ color: 'var(--c-text3)', margin: '0 auto' }} />
+          <div className="text-[14px] font-semibold" style={{ color: 'var(--c-white)' }}>No GSD projects found</div>
+          <div className="text-[12px] max-w-sm mx-auto" style={{ color: 'var(--c-text2)' }}>
+            GSD (Get Shit Done) is a structured AI workflow system that stores project plans and phases
+            inside a <code style={{ fontFamily: MONO }}>.planning/</code> directory. Run a data scan after
+            initializing a GSD project and it will appear here.
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  const completionRate = overview && overview.totalPhases > 0
+    ? Math.round((overview.completedPhases / overview.totalPhases) * 100)
+    : 0
+
+  const phaseStatuses = {
+    completed: overview?.completedPhases ?? 0,
+    executing: overview?.executingPhases ?? 0,
+    planned: overview?.plannedPhases ?? 0,
+  }
+
+  const statusDonutData = {
+    labels: ['Completed', 'Executing', 'Planned'],
+    datasets: [{
+      data: [phaseStatuses.completed, phaseStatuses.executing, phaseStatuses.planned],
+      backgroundColor: ['#22c55e', '#f59e0b', 'rgba(255,255,255,0.08)'],
+      borderWidth: 0,
+    }],
+  }
+
+  const topProjects = [...projects].sort((a, b) => b.total_phases - a.total_phases).slice(0, 8)
+  const projectBarData = {
+    labels: topProjects.map(p => p.name.length > 16 ? p.name.slice(0, 15) + '…' : p.name),
+    datasets: [
+      {
+        label: 'Completed',
+        data: topProjects.map(p => p.completed_phases),
+        backgroundColor: '#22c55e',
+        borderRadius: 2,
+      },
+      {
+        label: 'Remaining',
+        data: topProjects.map(p => p.total_phases - p.completed_phases),
+        backgroundColor: 'rgba(99,102,241,0.3)',
+        borderRadius: 2,
+      },
+    ],
+  }
+
+  const donutOpts = {
+    responsive: true, maintainAspectRatio: false, cutout: '72%',
+    plugins: {
+      legend: { display: false },
+      tooltip: { bodyFont: { family: MONO, size: 10 }, titleFont: { family: MONO, size: 10 } },
+    },
+  }
+
+  const barOpts = {
+    responsive: true, maintainAspectRatio: false, indexAxis: 'y',
+    scales: {
+      x: { stacked: true, grid: { color: gridColor }, ticks: { color: txtDim, font: { size: 8, family: MONO } } },
+      y: { stacked: true, grid: { display: false }, ticks: { color: txtColor, font: { size: 8, family: MONO } } },
+    },
+    plugins: {
+      legend: { display: false },
+      tooltip: { bodyFont: { family: MONO, size: 10 }, titleFont: { family: MONO, size: 10 } },
+    },
+  }
+
+  return (
+    <div className="fade-in space-y-3">
+      <PageHeader icon={Target} title="GSD Workflow" />
+
+      {/* KPIs */}
+      <div className="grid gap-2" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(90px, 1fr))' }}>
+        <KpiCard label="projects" value={overview?.totalProjects ?? projects.length} />
+        <KpiCard label="total phases" value={overview?.totalPhases ?? '—'} />
+        <KpiCard label="completed" value={overview?.completedPhases ?? '—'} />
+        <KpiCard label="completion" value={overview?.totalPhases > 0 ? `${completionRate}%` : '—'} />
+        <KpiCard label="total cost" value={allTokens ? formatCost(allTokens.totalCost) : '—'} />
+      </div>
+
+      {/* Charts */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-3">
+        <div className="card p-3">
+          <SectionTitle>phase status</SectionTitle>
+          <div className="flex items-center gap-4">
+            <div style={{ height: 110, width: 110, flexShrink: 0 }}>
+              <Doughnut data={statusDonutData} options={donutOpts} />
+            </div>
+            <div className="space-y-2 text-[11px]">
+              {[
+                { label: 'Completed', count: phaseStatuses.completed, color: '#22c55e' },
+                { label: 'Executing', count: phaseStatuses.executing, color: '#f59e0b' },
+                { label: 'Planned', count: phaseStatuses.planned, color: 'var(--c-text3)' },
+              ].map(({ label, count, color }) => (
+                <div key={label} className="flex items-center gap-2">
+                  <span className="w-2 h-2 rounded-full shrink-0" style={{ background: color }} />
+                  <span style={{ color: 'var(--c-text2)' }}>{label}</span>
+                  <span className="ml-auto font-bold tabular-nums" style={{ color, fontFamily: MONO }}>{count}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="card p-3 lg:col-span-2">
+          <SectionTitle>projects <span style={{ color: 'var(--c-text3)' }}>by phases</span></SectionTitle>
+          <div style={{ height: 130 }}>
+            <Bar data={projectBarData} options={barOpts} />
+          </div>
+          <div className="flex items-center gap-4 mt-2 text-[10px]" style={{ color: 'var(--c-text3)' }}>
+            <span className="flex items-center gap-1.5"><span className="inline-block w-2 h-2 rounded-sm" style={{ background: '#22c55e' }} /> Completed</span>
+            <span className="flex items-center gap-1.5"><span className="inline-block w-2 h-2 rounded-sm" style={{ background: 'rgba(99,102,241,0.3)' }} /> Remaining</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Project cards */}
+      <div className="space-y-2">
+        <SectionTitle>projects</SectionTitle>
+        {projects.map(project => (
+          <ProjectCard
+            key={project.folder}
+            project={project}
+            isExpanded={expandedFolder === project.folder}
+            onToggle={() => setExpandedFolder(prev => prev === project.folder ? null : project.folder)}
+            onOpenFile={handleOpenFile}
+            onOpenConfig={handleOpenConfig}
+            onOpenState={handleOpenState}
+          />
+        ))}
+      </div>
+
+      {/* Config popover — rendered at page level to escape overflow-hidden */}
+      {configPopover && (
+        <ConfigPopover
+          folder={configPopover.folder}
+          anchor={configPopover.anchor}
+          onClose={() => setConfigPopover(null)}
+        />
+      )}
+
+      {/* File sidebar */}
+      {fileSidebar && (
+        <FileSidebar
+          title={fileSidebar.title}
+          subtitle={fileSidebar.subtitle}
+          content={fileSidebar.content}
+          loading={fileSidebar.loading}
+          onClose={() => setFileSidebar(null)}
+        />
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add GSD (Get Shit Done) workflow tracking support that scans `.planning/` directories for project data
- New adapter parses PROJECT.md, ROADMAP.md, STATE.md, and phase artifacts (PLAN, RESEARCH, VERIFICATION, SUMMARY)
- Dedicated `/gsd` dashboard page with KPI cards, status donut chart, expandable project cards with phase timelines, file viewer sidebar, and per-phase token/cost correlation

## Changes
- `editors/gsd.js`: new adapter for scanning `.planning/` directories
- `cache.js`: two new tables (`gsd_projects`, `gsd_phases`), caching functions, token/cost correlation via time-window matching
- `server.js`: 7 REST endpoints under `/api/gsd/*`
- `ui/src/pages/GSD.jsx`: dashboard page with charts, project cards, and file sidebar
- `ui/src/lib/api.js`: client-side API functions
- `ui/src/App.jsx`: route and navigation entry