### PR TITLE
feat(relay): add HTTPS support to relay client

### DIFF
--- a/relay-client.js
+++ b/relay-client.js
@@ -1,5 +1,6 @@
 const chalk = require('chalk');
 const http = require('http');
+const https = require('https');
 const readline = require('readline');
 const crypto = require('crypto');
 
@@ -177,7 +178,7 @@ function collectProjectData(selectedFolders) {
 /**
  * POST data to relay server.
  */
-function postToRelay(host, port, username, data, authToken) {
+function postToRelay(scheme, host, port, username, data, authToken) {
   return new Promise((resolve, reject) => {
     const payload = JSON.stringify({
       username,
@@ -200,8 +201,8 @@ function postToRelay(host, port, username, data, authToken) {
       method: 'POST',
       headers,
     };
-
-    const req = http.request(options, (res) => {
+    const client = scheme === 'https' ? https : http
+    const req = client.request(options, (res) => {
       let body = '';
       res.on('data', (chunk) => { body += chunk; });
       res.on('end', () => {
@@ -234,6 +235,7 @@ async function startJoinClient(relayAddress, username) {
 
   // Parse host:port
   const parts = relayAddress.replace(/^https?:\/\//, '').split(':');
+  const scheme = relayAddress.startsWith("https://") ? "https" : 'http'
   const host = parts[0] || 'localhost';
   const port = parseInt(parts[1]) || 4638;
 
@@ -245,7 +247,7 @@ async function startJoinClient(relayAddress, username) {
 
   // Test connection
   try {
-    const testResult = await postToRelay(host, port, username, { projects: [], chats: [], messages: [], stats: [] }, authToken);
+    const testResult = await postToRelay(scheme, host, port, username, { projects: [], chats: [], messages: [], stats: [] }, authToken);
     if (!testResult.ok) {
       const msg = testResult.error || 'unknown error';
       if (msg === 'Unauthorized') {
@@ -278,7 +280,7 @@ async function startJoinClient(relayAddress, username) {
       cache.scanAll(() => {}, { resetCaches: true });
       const data = collectProjectData(selectedFolders);
       data.projects = selectedFolders;
-      const result = await postToRelay(host, port, username, data, authToken);
+      const result = await postToRelay(scheme, host, port, username, data, authToken);
       if (result.ok) {
         const s = result.synced || {};
         process.stdout.write(chalk.dim(`\r  ⟳ Synced: ${s.chats || 0} chats, ${s.messages || 0} messages — ${new Date().toLocaleTimeString()}    `));


### PR DESCRIPTION
Allow relay client to connect to servers using HTTPS by detecting the scheme from the relay address URL and using the appropriate Node.js http/https module.