### PR TITLE
feat(editors): add Codebuff adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
 <p align="center">
   <strong>Your Cursor, Windsurf, Claude Code sessions — analyzed, unified, tracked.</strong><br>
-  <sub>One command to turn scattered AI conversations from <b>16 editors</b> into a unified analytics dashboard.<br>Sessions, costs, models, tools — finally in one place. 100% local.</sub>
+  <sub>One command to turn scattered AI conversations from <b>17 editors</b> into a unified analytics dashboard.<br>Sessions, costs, models, tools — finally in one place. 100% local.</sub>
 </p>
 
 <p align="center">
   <a href="https://www.npmjs.com/package/agentlytics"><img src="https://img.shields.io/npm/v/agentlytics?color=6366f1&label=npm" alt="npm"></a>
-  <a href="#supported-editors"><img src="https://img.shields.io/badge/editors-16-818cf8" alt="editors"></a>
+  <a href="#supported-editors"><img src="https://img.shields.io/badge/editors-17-818cf8" alt="editors"></a>
   <a href="#license"><img src="https://img.shields.io/badge/license-MIT-green" alt="license"></a>
   <a href="https://nodejs.org"><img src="https://img.shields.io/badge/node-%E2%89%A520.19%20%7C%20%E2%89%A522.12-brightgreen" alt="node"></a>
   <a href="https://deno.land"><img src="https://img.shields.io/badge/deno-%E2%89%A52.0-000?logo=deno" alt="deno"></a>
@@ -154,6 +154,7 @@ npx agentlytics --collect
 | **Command Code** | ✅ | ✅ | ❌ | ❌ |
 | **Goose** | ✅ | ✅ | ✅ | ❌ |
 | **Kiro** | ✅ | ✅ | ✅ | ❌ |
+| **Codebuff** | ✅ | ✅ | ⚠️ | ⚠️ |
 
 > Windsurf, Windsurf Next, and Antigravity must be running during scan.
 

--- a/editors/codebuff.js
+++ b/editors/codebuff.js
@@ -1,0 +1,338 @@
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+// ============================================================
+// Codebuff adapter
+// ------------------------------------------------------------
+// Codebuff persists chats under ~/.config/manicode (the legacy folder name
+// — the product was previously called Manicode). Non-prod builds use
+// manicode-dev / manicode-staging. Layout:
+//
+//   ~/.config/manicode/projects/<projectBasename>/chats/<chatId>/
+//     ├── chat-messages.json   // serialized ChatMessage[]
+//     ├── run-state.json       // SDK RunState (has real `cwd`)
+//     └── log.jsonl            // internal logs (ignored)
+//
+// chatId is an ISO timestamp with ':' replaced by '-'. We use
+// "<projectBasename>::<chatId>" as composerId to avoid collisions when
+// two different projects share the same folder basename.
+// ============================================================
+
+const HOME = os.homedir();
+
+function getProjectRoots() {
+  const roots = [];
+  for (const variant of ['manicode', 'manicode-dev', 'manicode-staging']) {
+    const projectsDir = path.join(HOME, '.config', variant, 'projects');
+    if (fs.existsSync(projectsDir)) roots.push({ variant, projectsDir });
+  }
+  return roots;
+}
+
+function safeReadJson(filePath) {
+  try { return JSON.parse(fs.readFileSync(filePath, 'utf-8')); } catch { return null; }
+}
+
+function parseChatIdToTs(chatId) {
+  // Codebuff chatIds look like "2026-04-21T16-34-12.000Z" — reverse the
+  // substitution so we get a real ISO timestamp back.
+  if (!chatId) return null;
+  const iso = chatId.replace(/(\d{4}-\d{2}-\d{2}T\d{2})-(\d{2})-(\d{2})/, '$1:$2:$3');
+  const ts = Date.parse(iso);
+  return Number.isFinite(ts) ? ts : null;
+}
+
+function cleanPrompt(text) {
+  if (!text) return null;
+  const clean = String(text).replace(/\s+/g, ' ').trim().substring(0, 120);
+  return clean || null;
+}
+
+function extractCwdFromRunState(runState) {
+  if (!runState) return null;
+  // Common shapes: { sessionState: { ... cwd }, output } or { cwd } at root.
+  const candidates = [
+    runState?.sessionState?.projectContext?.cwd,
+    runState?.sessionState?.fileContext?.cwd,
+    runState?.sessionState?.cwd,
+    runState?.cwd,
+  ];
+  for (const c of candidates) if (typeof c === 'string' && c) return c;
+  return null;
+}
+
+// --- Best-effort model / token extraction ---
+
+function pickNumber(...vals) {
+  for (const v of vals) {
+    if (typeof v === 'number' && Number.isFinite(v)) return v;
+  }
+  return undefined;
+}
+
+function extractUsageFromMetadata(meta) {
+  if (!meta || typeof meta !== 'object') return {};
+  const cb = meta.codebuff && typeof meta.codebuff === 'object' ? meta.codebuff : null;
+  const usage = (cb && cb.usage) || meta.usage || null;
+  if (!usage || typeof usage !== 'object') return {};
+  return {
+    inputTokens: pickNumber(usage.inputTokens, usage.promptTokens, usage.prompt_tokens, usage.input_tokens),
+    outputTokens: pickNumber(usage.outputTokens, usage.completionTokens, usage.completion_tokens, usage.output_tokens),
+    cacheRead: pickNumber(
+      usage.cacheReadInputTokens, usage.cache_read_input_tokens,
+      usage?.promptTokensDetails?.cachedTokens, usage?.prompt_tokens_details?.cached_tokens,
+    ),
+    cacheWrite: pickNumber(
+      usage.cacheCreationInputTokens, usage.cache_creation_input_tokens,
+      usage.cachedTokensCreated,
+    ),
+  };
+}
+
+function extractMessageUsageAndModel(msg) {
+  // Codebuff ChatMessage shape allows metadata.runState to stash the SDK
+  // RunState after completion. Model + usage isn't guaranteed to be there
+  // but we try a few known spots.
+  const out = { model: undefined, inputTokens: undefined, outputTokens: undefined, cacheRead: undefined, cacheWrite: undefined };
+  const meta = msg?.metadata;
+  if (!meta || typeof meta !== 'object') return out;
+
+  // Direct provider hints some Codebuff builds attach.
+  if (typeof meta.model === 'string') out.model = meta.model;
+  if (typeof meta.modelId === 'string' && !out.model) out.model = meta.modelId;
+
+  // Token totals may live on metadata.usage or inside providerMetadata.
+  const usageDirect = extractUsageFromMetadata(meta);
+  Object.assign(out, {
+    inputTokens: out.inputTokens ?? usageDirect.inputTokens,
+    outputTokens: out.outputTokens ?? usageDirect.outputTokens,
+    cacheRead: out.cacheRead ?? usageDirect.cacheRead,
+    cacheWrite: out.cacheWrite ?? usageDirect.cacheWrite,
+  });
+
+  // Walk the RunState stash for the most recent assistant message with
+  // providerOptions that carry OpenRouter-style usage.
+  const rs = meta.runState;
+  if (rs && typeof rs === 'object') {
+    const history = rs?.sessionState?.mainAgentState?.messageHistory;
+    if (Array.isArray(history)) {
+      for (let i = history.length - 1; i >= 0; i--) {
+        const m = history[i];
+        if (m?.role !== 'assistant') continue;
+        const po = m.providerOptions;
+        const u = extractUsageFromMetadata(po);
+        if (u.inputTokens != null || u.outputTokens != null) {
+          out.inputTokens = out.inputTokens ?? u.inputTokens;
+          out.outputTokens = out.outputTokens ?? u.outputTokens;
+          out.cacheRead = out.cacheRead ?? u.cacheRead;
+          out.cacheWrite = out.cacheWrite ?? u.cacheWrite;
+          if (!out.model && typeof po?.codebuff?.model === 'string') out.model = po.codebuff.model;
+          break;
+        }
+      }
+    }
+  }
+
+  return out;
+}
+
+// --- Block flattening: turn Codebuff ChatMessage blocks into a single
+// transcript-style content string + normalized tool-call list. ---
+
+function flattenBlocks(blocks, out = { parts: [], toolCalls: [] }, depth = 0) {
+  if (!Array.isArray(blocks)) return out;
+  const indent = depth ? '  '.repeat(depth) : '';
+  for (const block of blocks) {
+    if (!block || typeof block !== 'object') continue;
+    switch (block.type) {
+      case 'text': {
+        if (typeof block.content !== 'string' || !block.content) break;
+        if (block.textType === 'reasoning') {
+          out.parts.push(`${indent}[thinking] ${block.content}`);
+        } else {
+          out.parts.push(`${indent}${block.content}`);
+        }
+        break;
+      }
+      case 'tool': {
+        const toolName = block.toolName || 'tool';
+        const input = block.input || {};
+        const argKeys = (input && typeof input === 'object') ? Object.keys(input).join(', ') : '';
+        out.parts.push(`${indent}[tool-call: ${toolName}(${argKeys})]`);
+        out.toolCalls.push({ name: toolName, args: input });
+        if (typeof block.output === 'string' && block.output) {
+          out.parts.push(`${indent}[tool-result] ${block.output.substring(0, 500)}`);
+        }
+        break;
+      }
+      case 'agent': {
+        const name = block.agentName || block.agentType || 'agent';
+        const status = block.status ? ` (${block.status})` : '';
+        out.parts.push(`${indent}[subagent: ${name}${status}]`);
+        if (typeof block.content === 'string' && block.content) {
+          out.parts.push(`${indent}  ${block.content}`);
+        }
+        flattenBlocks(block.blocks, out, depth + 1);
+        break;
+      }
+      case 'plan': {
+        if (typeof block.content === 'string' && block.content) {
+          out.parts.push(`${indent}[plan]\n${block.content}`);
+        }
+        break;
+      }
+      case 'mode-divider': {
+        if (block.mode) out.parts.push(`${indent}[mode: ${block.mode}]`);
+        break;
+      }
+      case 'ask-user': {
+        const qs = Array.isArray(block.questions) ? block.questions : [];
+        for (const q of qs) {
+          if (q?.question) out.parts.push(`${indent}[ask-user] ${q.question}`);
+        }
+        break;
+      }
+      case 'image': {
+        out.parts.push(`${indent}[image${block.filename ? `: ${block.filename}` : ''}]`);
+        break;
+      }
+      default:
+        break;
+    }
+  }
+  return out;
+}
+
+// ============================================================
+// Adapter interface
+// ============================================================
+
+const name = 'codebuff';
+const labels = { 'codebuff': 'Codebuff' };
+
+function getChats() {
+  const chats = [];
+  const roots = getProjectRoots();
+  if (roots.length === 0) return chats;
+
+  for (const { variant, projectsDir } of roots) {
+    let projectDirs;
+    try { projectDirs = fs.readdirSync(projectsDir); } catch { continue; }
+    // Only the non-prod variants get prefixed so the prod composerId stays clean.
+    const variantPrefix = variant === 'manicode' ? '' : `${variant}::`;
+
+    for (const projectBase of projectDirs) {
+      const projectDir = path.join(projectsDir, projectBase);
+      try { if (!fs.statSync(projectDir).isDirectory()) continue; } catch { continue; }
+
+      const chatsDir = path.join(projectDir, 'chats');
+      if (!fs.existsSync(chatsDir)) continue;
+
+      let chatIds;
+      try { chatIds = fs.readdirSync(chatsDir); } catch { continue; }
+
+      for (const chatId of chatIds) {
+        const chatDir = path.join(chatsDir, chatId);
+        let dirStat;
+        try { dirStat = fs.statSync(chatDir); } catch { continue; }
+        if (!dirStat.isDirectory()) continue;
+
+        const messagesPath = path.join(chatDir, 'chat-messages.json');
+        if (!fs.existsSync(messagesPath)) continue;
+
+        // Light peek for title + message count — don't hydrate blocks here.
+        const messages = safeReadJson(messagesPath);
+        if (!Array.isArray(messages) || messages.length === 0) continue;
+
+        const firstUser = messages.find((m) => m && m.variant === 'user' && typeof m.content === 'string');
+        const title = cleanPrompt(firstUser && firstUser.content);
+
+        // Recover the real cwd so Agentlytics can group by project correctly.
+        const runState = safeReadJson(path.join(chatDir, 'run-state.json'));
+        const folder = extractCwdFromRunState(runState) || null;
+
+        chats.push({
+          source: 'codebuff',
+          composerId: `${variantPrefix}${projectBase}::${chatId}`,
+          name: title,
+          createdAt: parseChatIdToTs(chatId),
+          lastUpdatedAt: dirStat.mtime.getTime(),
+          mode: 'codebuff',
+          folder,
+          encrypted: false,
+          bubbleCount: messages.length,
+          _fullPath: chatDir,
+        });
+      }
+    }
+  }
+
+  return chats;
+}
+
+function getMessages(chat) {
+  const chatDir = chat._fullPath;
+  if (!chatDir) return [];
+  const messagesPath = path.join(chatDir, 'chat-messages.json');
+  if (!fs.existsSync(messagesPath)) return [];
+
+  const raw = safeReadJson(messagesPath);
+  if (!Array.isArray(raw)) return [];
+
+  const out = [];
+  for (const msg of raw) {
+    if (!msg || typeof msg !== 'object') continue;
+    const variant = msg.variant;
+
+    if (variant === 'user') {
+      const content = typeof msg.content === 'string' ? msg.content : '';
+      if (content) out.push({ role: 'user', content });
+      continue;
+    }
+
+    if (variant === 'error') {
+      const content = typeof msg.content === 'string' ? msg.content : '';
+      if (content) out.push({ role: 'system', content: `[error] ${content}` });
+      continue;
+    }
+
+    if (variant === 'ai' || variant === 'agent') {
+      const flattened = flattenBlocks(msg.blocks);
+      const parts = [];
+      if (typeof msg.content === 'string' && msg.content) parts.push(msg.content);
+      if (flattened.parts.length) parts.push(flattened.parts.join('\n'));
+      const content = parts.join('\n').trim();
+      if (!content) continue;
+
+      const { model, inputTokens, outputTokens, cacheRead, cacheWrite } = extractMessageUsageAndModel(msg);
+
+      out.push({
+        role: 'assistant',
+        content,
+        _model: model,
+        _inputTokens: inputTokens,
+        _outputTokens: outputTokens,
+        _cacheRead: cacheRead,
+        _cacheWrite: cacheWrite,
+        _toolCalls: flattened.toolCalls.length ? flattened.toolCalls : undefined,
+        _credits: typeof msg.credits === 'number' ? msg.credits : undefined,
+      });
+      continue;
+    }
+  }
+
+  return out;
+}
+
+function getArtifacts(folder) {
+  const { scanArtifacts } = require('./base');
+  return scanArtifacts(folder, {
+    editor: 'codebuff',
+    label: 'Codebuff',
+    files: ['.codebuffignore', '.manicodeignore', 'knowledge.md'],
+    dirs: ['.agents'],
+  });
+}
+
+module.exports = { name, labels, getChats, getMessages, getArtifacts };

--- a/editors/index.js
+++ b/editors/index.js
@@ -12,8 +12,9 @@ const cursorAgent = require('./cursor-agent');
 const commandcode = require('./commandcode');
 const goose = require('./goose');
 const kiro = require('./kiro');
+const codebuff = require('./codebuff');
 
-const editors = [cursor, windsurf, antigravity, claude, vscode, zed, opencode, codex, gemini, copilot, cursorAgent, commandcode, goose, kiro];
+const editors = [cursor, windsurf, antigravity, claude, vscode, zed, opencode, codex, gemini, copilot, cursorAgent, commandcode, goose, kiro, codebuff];
 
 // Build a unified source → display-label map from all editor modules
 const editorLabels = {};

--- a/mod.ts
+++ b/mod.ts
@@ -829,6 +829,85 @@ function formatDate(ts: number | null): string {
   return d.toISOString().split("T")[0];
 }
 
+// ── Editor: Codebuff ────────────────────────────────────────
+
+function scanCodebuff(): EditorResult {
+  const result: EditorResult = { name: "codebuff", label: "Codebuff", detected: false, sessions: [] };
+  const variants = ["manicode", "manicode-dev", "manicode-staging"];
+
+  for (const variant of variants) {
+    const projectsDir = join(HOME, ".config", variant, "projects");
+    if (!existsSync(projectsDir)) continue;
+    result.detected = true;
+    const variantPrefix = variant === "manicode" ? "" : `${variant}::`;
+
+    for (const projectBase of readDirNames(projectsDir)) {
+      const projectDir = join(projectsDir, projectBase);
+      if (!isDirectory(projectDir)) continue;
+
+      const chatsDir = join(projectDir, "chats");
+      if (!existsSync(chatsDir)) continue;
+
+      for (const chatId of readDirNames(chatsDir)) {
+        const chatDir = join(chatsDir, chatId);
+        if (!isDirectory(chatDir)) continue;
+
+        const messagesPath = join(chatDir, "chat-messages.json");
+        if (!existsSync(messagesPath)) continue;
+
+        let messages: any[] = [];
+        try {
+          const parsedMessages = JSON.parse(readTextSync(messagesPath));
+          if (Array.isArray(parsedMessages)) messages = parsedMessages;
+        } catch { /* skip */ }
+        if (messages.length === 0) continue;
+
+        let firstUser: string | null = null;
+        for (const m of messages) {
+          if (m && m.variant === "user" && typeof m.content === "string") {
+            firstUser = m.content.substring(0, 120);
+            break;
+          }
+        }
+
+        // Try to recover the real cwd from run-state.json
+        let folder: string | null = null;
+        const runStatePath = join(chatDir, "run-state.json");
+        if (existsSync(runStatePath)) {
+          try {
+            const rs = JSON.parse(readTextSync(runStatePath));
+            folder = rs?.sessionState?.projectContext?.cwd
+              || rs?.sessionState?.fileContext?.cwd
+              || rs?.sessionState?.cwd
+              || rs?.cwd
+              || null;
+          } catch { /* skip */ }
+        }
+
+        // chatId is an ISO timestamp with ':' replaced by '-'; reverse it.
+        let createdAt: number | null = null;
+        const isoFixed = chatId.replace(/(\d{4}-\d{2}-\d{2}T\d{2})-(\d{2})-(\d{2})/, "$1:$2:$3");
+        const parsedTs = Date.parse(isoFixed);
+        if (Number.isFinite(parsedTs)) createdAt = parsedTs;
+
+        result.sessions.push({
+          source: "codebuff",
+          composerId: `${variantPrefix}${projectBase}::${chatId}`,
+          name: firstUser,
+          createdAt,
+          lastUpdatedAt: fileMtime(chatDir),
+          mode: "codebuff",
+          folder,
+          bubbleCount: messages.length,
+          messageCount: messages.length,
+        });
+      }
+    }
+  }
+
+  return result;
+}
+
 function formatRelative(ts: number | null): string {
   if (!ts) return "";
   const diff = Date.now() - ts;
@@ -888,6 +967,7 @@ ${bold("Full version:")}
   allResults.push(scanOpenCode());
   allResults.push(...scanWindsurf());
   allResults.push(scanZed());
+  allResults.push(scanCodebuff());
 
   // Gather all sessions
   const allSessions = allResults.flatMap((r) => r.sessions);

--- a/ui/src/lib/constants.js
+++ b/ui/src/lib/constants.js
@@ -16,6 +16,7 @@ export const EDITOR_COLORS = {
   'commandcode': '#e11d48',
   'goose': '#333333',
   'kiro': '#ff9900',
+  'codebuff': '#44ff00',
 };
 
 export const EDITOR_LABELS = {
@@ -36,6 +37,7 @@ export const EDITOR_LABELS = {
   'commandcode': 'Command Code',
   'goose': 'Goose',
   'kiro': 'Kiro',
+  'codebuff': 'Codebuff',
 };
 
 export function editorColor(src) {


### PR DESCRIPTION
Adds a new editor adapter for [Codebuff](https://github.com/CodebuffAI/codebuff) — the open-source multi-agent AI coding CLI. This brings Agentlytics editor count to **17**.

## What it does

Codebuff persists chat history on disk at `~/.config/manicode/projects/<basename>/chats/<chatId>/` (the `manicode` folder name is legacy — the product was previously called Manicode). The new adapter reads that data and maps it into the standard Agentlytics chat/message shape.

Layout handled:

```
~/.config/manicode/projects/<projectBasename>/chats/<chatId>/
  ├── chat-messages.json   # serialized ChatMessage[]
  ├── run-state.json       # SDK RunState (contains the real cwd)
  └── log.jsonl            # internal logs (ignored)
```

## Highlights

- **Chats + messages** — full transcripts via `chat-messages.json`.
- **Real project folder recovery** — `run-state.json` carries the actual `cwd`, so chats group under the right project in the UI instead of just the folder basename.
- **Tool calls** — `ToolContentBlock` entries are flattened into `[tool-call: name(argKeys)]` lines and populate `_toolCalls` for the analytics panel.
- **Sub-agents + reasoning + plan/ask-user/image blocks** — all preserved in transcript form with indentation for nested agents.
- **Credits per assistant message** — surfaced on the message object.
- **Artifacts** — `.codebuffignore`, `.manicodeignore`, `knowledge.md` and the `.agents/` directory.
- **Deno parity** — `scanCodebuff()` added to `mod.ts` so the sandboxed `deno run` CLI picks up Codebuff too.
- **Multi-variant safe** — `manicode`, `manicode-dev` and `manicode-staging` are all scanned; composer IDs are prefixed with the variant for the non-prod ones so keys never collide in the cache.

## Limitations (documented with ⚠️ in the supported-editors table)

- **Models** — Codebuff's `chat-messages.json` does not record the LLM model per message. The adapter scans `metadata.runState` / `providerOptions` as a best-effort fallback. If/when Codebuff persists usage, this will light up automatically.
- **Tokens** — same story as models (extraction logic is already in place).
- **Credits** are opaque Codebuff units; `pricing.js` does not compute USD for them.

## Tested locally

| Check | Result |
|---|---|
| `node -e "require('./editors/codebuff').getChats().length"` | 17 chats |
| Folder recovery | 17/17 with correct absolute `cwd` |
| Messages | 170 |
| Tool calls | 936 (top: `run_terminal_command` 427, `set_output` 305, `suggest_followups` 66, `read_files` 46) |
| `node index.js --collect` | `✓ Codebuff 17 sessions`, cache DB populated with `source = 'codebuff'` rows in `chats`/`messages`/`tool_calls` |
| `deno check mod.ts` | passes |
| `deno run --allow-read --allow-env mod.ts --json` | `codebuff - detected - 17 sessions` |

## Files

- `editors/codebuff.js` (new) — the adapter.
- `editors/index.js` — registers the adapter.
- `mod.ts` — Deno sandboxed scanner parity.
- `ui/src/lib/constants.js` — Codebuff color `#44ff00` + label.
- `README.md` — editor count badge 16 → 17 and new supported-editors row.

## Not in this PR

- `docs/index.html` landing page still says "16 editors" in 3 spots; left for a separate marketing-copy update.
- `getUsage()` against the Codebuff credit API — gated on `allowSubscriptionAccess` and worth its own PR.
- `getMCPServers()` — Codebuff doesn't ship a conventional `mcpServers` config today.
